### PR TITLE
2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>fr.nocsy</groupId>
     <artifactId>mcpets</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.18.2-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>io.lumine</groupId>
             <artifactId>Mythic-Dist</artifactId>
-            <version>5.0.3-SNAPSHOT</version>
+            <version>5.0.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/fr/nocsy/mcpets/MCPets.java
+++ b/src/main/java/fr/nocsy/mcpets/MCPets.java
@@ -6,6 +6,7 @@ import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.config.*;
 import fr.nocsy.mcpets.data.flags.AbstractFlag;
 import fr.nocsy.mcpets.data.flags.FlagsManager;
+import fr.nocsy.mcpets.data.inventories.CategoriesMenu;
 import fr.nocsy.mcpets.data.inventories.PlayerData;
 import fr.nocsy.mcpets.data.sql.Databases;
 import fr.nocsy.mcpets.listeners.EventListener;

--- a/src/main/java/fr/nocsy/mcpets/MCPets.java
+++ b/src/main/java/fr/nocsy/mcpets/MCPets.java
@@ -3,11 +3,7 @@ package fr.nocsy.mcpets;
 import com.sk89q.worldguard.WorldGuard;
 import fr.nocsy.mcpets.commands.CommandHandler;
 import fr.nocsy.mcpets.data.Pet;
-import fr.nocsy.mcpets.data.config.AbstractConfig;
-import fr.nocsy.mcpets.data.config.BlacklistConfig;
-import fr.nocsy.mcpets.data.config.GlobalConfig;
-import fr.nocsy.mcpets.data.config.LanguageConfig;
-import fr.nocsy.mcpets.data.config.PetConfig;
+import fr.nocsy.mcpets.data.config.*;
 import fr.nocsy.mcpets.data.flags.AbstractFlag;
 import fr.nocsy.mcpets.data.flags.FlagsManager;
 import fr.nocsy.mcpets.data.inventories.PlayerData;
@@ -37,6 +33,7 @@ public class MCPets extends JavaPlugin {
     private static final String logName = "[MCPets] : ";
 
     public static void loadConfigs() {
+        ItemsListConfig.getInstance().init();
         GlobalConfig.getInstance().init();
         LanguageConfig.getInstance().init();
         BlacklistConfig.getInstance().init();

--- a/src/main/java/fr/nocsy/mcpets/MCPets.java
+++ b/src/main/java/fr/nocsy/mcpets/MCPets.java
@@ -38,6 +38,7 @@ public class MCPets extends JavaPlugin {
         LanguageConfig.getInstance().init();
         BlacklistConfig.getInstance().init();
         PetConfig.loadPets(AbstractConfig.getPath() + "Pets/", true);
+        CategoryConfig.load(AbstractConfig.getPath() + "Categories/", true);
         Databases.init();
         PlayerData.initAll();
     }

--- a/src/main/java/fr/nocsy/mcpets/commands/MCPetsCommand.java
+++ b/src/main/java/fr/nocsy/mcpets/commands/MCPetsCommand.java
@@ -36,16 +36,24 @@ public class MCPetsCommand implements CCommand {
     @Override
     public void execute(CommandSender sender, Command command, String label, String[] args) {
         if (sender.hasPermission(getPermission())) {
-            if (args.length == 4) {
+            if (args.length == 4 || args.length == 5)
+            {
                 if (args[0].equalsIgnoreCase("spawn")
-                        && sender.hasPermission(getAdminPermission())) {
+                        && sender.hasPermission(getAdminPermission()))
+                {
 
                     String petId = args[1];
                     String playerName = args[2];
                     String booleanValue = args[3];
+                    boolean silent = false;
+                    if (args.length == 5 && args[4].equals("-s"))
+                    {
+                        silent = true;
+                    }
 
                     Player target = Bukkit.getPlayer(playerName);
-                    if (target == null) {
+                    if (target == null)
+                    {
                         Language.PLAYER_NOT_CONNECTED.sendMessageFormated(sender, new FormatArg("%player%", playerName));
                         return;
                     }
@@ -58,12 +66,16 @@ public class MCPetsCommand implements CCommand {
                     Pet pet = petObject.copy();
 
                     boolean checkPermission = booleanValue.equalsIgnoreCase("true");
-                    if (checkPermission && !target.hasPermission(pet.getPermission())) {
+                    if (checkPermission && !target.hasPermission(pet.getPermission()))
+                    {
                         Language.NOT_ALLOWED.sendMessage(target);
                         return;
                     }
                     pet.setCheckPermission(checkPermission);
-                    pet.spawnWithMessage(target, target.getLocation());
+                    if (silent)
+                        pet.spawn(target, target.getLocation());
+                    else
+                        pet.spawnWithMessage(target, target.getLocation());
                     return;
                 }
             }

--- a/src/main/java/fr/nocsy/mcpets/commands/MCPetsCommand.java
+++ b/src/main/java/fr/nocsy/mcpets/commands/MCPetsCommand.java
@@ -253,6 +253,9 @@ public class MCPetsCommand implements CCommand {
                         case "mount":
                             PetInteractionMenuListener.mount(p, pet);
                             return;
+                        case "inventory":
+                            PetInteractionMenuListener.inventory(p, pet);
+                            return;
                         case "revoke":
                             PetInteractionMenuListener.revoke(p, pet);
                             return;

--- a/src/main/java/fr/nocsy/mcpets/commands/MCPetsCommand.java
+++ b/src/main/java/fr/nocsy/mcpets/commands/MCPetsCommand.java
@@ -2,6 +2,7 @@ package fr.nocsy.mcpets.commands;
 
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.PPermission;
+import fr.nocsy.mcpets.data.Items;
 import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.config.FormatArg;
 import fr.nocsy.mcpets.data.config.ItemsListConfig;
@@ -13,6 +14,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 
@@ -199,6 +201,30 @@ public class MCPetsCommand implements CCommand {
                         return;
                     }
 
+                }
+                if(args[0].equalsIgnoreCase("signalstick")
+                        && sender.hasPermission(getAdminPermission())
+                        && sender instanceof Player)
+                {
+                    String petId = args[1];
+                    Pet pet = Pet.getFromId(petId);
+                    if(pet == null)
+                    {
+                        Language.PET_DOESNT_EXIST.sendMessage(sender);
+                        return;
+                    }
+
+                    Player p = ((Player)sender);
+                    ItemStack it = p.getInventory().getItemInMainHand();
+                    if(it == null ||
+                            it.getType().isAir())
+                    {
+                        Language.REQUIRES_ITEM_IN_HAND.sendMessage(p);
+                        return;
+                    }
+
+                    ((Player)sender).getInventory().setItemInMainHand(Items.turnIntoSignalStick(it, pet));
+                    return;
                 }
             } else if (args.length == 1) {
                 if (args[0].equalsIgnoreCase("reload")

--- a/src/main/java/fr/nocsy/mcpets/commands/MCPetsCommand.java
+++ b/src/main/java/fr/nocsy/mcpets/commands/MCPetsCommand.java
@@ -144,6 +144,7 @@ public class MCPetsCommand implements CCommand {
 
                             ItemsListConfig.getInstance().setItemStack(key, item);
                             Language.KEY_ADDED.sendMessage(p);
+                            return;
                         }
                         else if(action.equalsIgnoreCase("give"))
                         {
@@ -204,12 +205,12 @@ public class MCPetsCommand implements CCommand {
                     if(ItemsListConfig.getInstance().getItemStack(key) != null)
                     {
                         ItemsListConfig.getInstance().setItemStack(key, item);
-                        Language.ITEM_UPDATED.sendMessageFormated(p, new FormatArg("key", key));
+                        Language.ITEM_UPDATED.sendMessageFormated(p, new FormatArg("%key%", key));
                         return;
                     }
                     else
                     {
-                        Language.ITEM_DOESNT_EXIST.sendMessageFormated(p, new FormatArg("key", key));
+                        Language.ITEM_DOESNT_EXIST.sendMessageFormated(p, new FormatArg("%key%", key));
                         return;
                     }
 

--- a/src/main/java/fr/nocsy/mcpets/data/Category.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Category.java
@@ -5,6 +5,7 @@ import fr.nocsy.mcpets.data.config.Language;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Cat;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -16,10 +17,10 @@ import java.util.Optional;
 public class Category {
 
     @Getter
-    private static ArrayList<Category> categories;
+    private static ArrayList<Category> categories = new ArrayList<Category>();
 
     @Getter
-    private String id;
+    private final String id;
 
     @Getter
     @Setter
@@ -42,7 +43,7 @@ public class Category {
 
     public boolean openInventory(Player p, int page)
     {
-        if(page > maxPages)
+        if(page > maxPages || page < 0)
             return false;
 
         int invSize = pets.size() - page*52;
@@ -57,7 +58,7 @@ public class Category {
                 break;
             Pet pet = pets.get(i);
             if(pet.has(p))
-                showedPets.add(pets.get(i));
+                showedPets.add(pet);
         }
 
         if(showedPets.isEmpty() && page > 0)
@@ -71,12 +72,14 @@ public class Category {
             Pet pet = showedPets.get(i);
             inventory.setItem(i, pet.getIcon());
         }
+        p.openInventory(inventory);
         return true;
     }
 
     public void addPet(Pet pet)
     {
-        pets.add(pet);
+        if(!pets.contains(pet))
+            pets.add(pet);
     }
 
     public void countMaxPages()
@@ -102,12 +105,13 @@ public class Category {
     {
         ItemMeta meta = icon.getItemMeta();
         meta.setLocalizedName("MCPetsCategory;" + this.getId());
+        meta.setDisplayName(displayName);
         ArrayList<String> lore = (ArrayList<String>) meta.getLore() != null
                 ? (ArrayList<String>) meta.getLore()
                 : new ArrayList<>();
 
         lore.add(" ");
-        lore.add(Language.CATEGORY_PET_AMOUNT.getMessageFormatted(new FormatArg("petamount", Integer.toString(pets.size()))));
+        lore.add(Language.CATEGORY_PET_AMOUNT.getMessageFormatted(new FormatArg("%petAmount%", Integer.toString(pets.size()))));
         meta.setLore(lore);
         icon.setItemMeta(meta);
     }

--- a/src/main/java/fr/nocsy/mcpets/data/Category.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Category.java
@@ -1,0 +1,72 @@
+package fr.nocsy.mcpets.data;
+
+import fr.nocsy.mcpets.data.config.FormatArg;
+import fr.nocsy.mcpets.data.config.Language;
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+
+public class Category {
+
+    @Getter
+    private static ArrayList<Category> categories;
+
+
+    @Getter
+    private String id;
+
+    @Getter
+    @Setter
+    private String displayName;
+    @Getter
+    private ItemStack icon;
+    @Getter
+    private ArrayList<Pet> pets;
+
+    public Category(String id)
+    {
+        this.id = id;
+        this.icon = null;
+        this.pets = new ArrayList<>();
+        this.displayName = "Unknown";
+    }
+
+    public static void init()
+    {
+
+    }
+
+    public void addPet(Pet pet)
+    {
+        pets.add(pet);
+    }
+
+    public void setIcon(ItemStack it)
+    {
+        icon = it;
+        setupLore();
+    }
+
+
+    private void setupLore()
+    {
+        ItemMeta meta = icon.getItemMeta();
+        ArrayList<String> lore = (ArrayList<String>) meta.getLore() != null
+                ? (ArrayList<String>) meta.getLore()
+                : new ArrayList<>();
+
+        lore.add(" ");
+        lore.add(Language.CATEGORY_PET_AMOUNT.getMessageFormatted(new FormatArg("petamount", Integer.toString(pets.size()))));
+        meta.setLore(lore);
+        icon.setItemMeta(meta);
+    }
+
+    public static void add(Category category)
+    {
+        categories.add(category);
+    }
+
+}

--- a/src/main/java/fr/nocsy/mcpets/data/Category.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Category.java
@@ -4,16 +4,19 @@ import fr.nocsy.mcpets.data.config.FormatArg;
 import fr.nocsy.mcpets.data.config.Language;
 import lombok.Getter;
 import lombok.Setter;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 public class Category {
 
     @Getter
     private static ArrayList<Category> categories;
-
 
     @Getter
     private String id;
@@ -26,6 +29,9 @@ public class Category {
     @Getter
     private ArrayList<Pet> pets;
 
+    @Getter
+    private int maxPages;
+
     public Category(String id)
     {
         this.id = id;
@@ -34,9 +40,38 @@ public class Category {
         this.displayName = "Unknown";
     }
 
-    public static void init()
+    public boolean openInventory(Player p, int page)
     {
+        if(page > maxPages)
+            return false;
 
+        int invSize = pets.size() - page*52;
+        while(invSize <= 0 || invSize%9 != 0)
+        {
+            invSize++;
+        }
+        ArrayList<Pet> showedPets = new ArrayList<>();
+        for(int i = page*52; i < pets.size(); i++)
+        {
+            if(showedPets.size() >= invSize-1)
+                break;
+            Pet pet = pets.get(i);
+            if(pet.has(p))
+                showedPets.add(pets.get(i));
+        }
+
+        if(showedPets.isEmpty() && page > 0)
+            return false;
+
+        Inventory inventory = Bukkit.createInventory(null, invSize, displayName);
+
+        inventory.setItem(invSize-1, Items.page(this, page));
+        for(int i = 0; i < showedPets.size(); i++)
+        {
+            Pet pet = showedPets.get(i);
+            inventory.setItem(i, pet.getIcon());
+        }
+        return true;
     }
 
     public void addPet(Pet pet)
@@ -44,16 +79,29 @@ public class Category {
         pets.add(pet);
     }
 
+    public void countMaxPages()
+    {
+        this.maxPages = 1;
+        int count = pets.size();
+        while(count > 0)
+        {
+            if(count%53 == 0)
+                maxPages++;
+            count--;
+        }
+    }
+
     public void setIcon(ItemStack it)
     {
         icon = it;
-        setupLore();
+        setupData();
     }
 
 
-    private void setupLore()
+    private void setupData()
     {
         ItemMeta meta = icon.getItemMeta();
+        meta.setLocalizedName("MCPetsCategory;" + this.getId());
         ArrayList<String> lore = (ArrayList<String>) meta.getLore() != null
                 ? (ArrayList<String>) meta.getLore()
                 : new ArrayList<>();
@@ -64,9 +112,85 @@ public class Category {
         icon.setItemMeta(meta);
     }
 
+    /**
+     * Return the page associated to the said inventory
+     * -1 if no category is found
+     * @param inventory
+     * @return
+     */
+    public int getCurrentPage(Inventory inventory)
+    {
+        if(inventory == null)
+            return -1;
+
+        ItemStack pager = inventory.getItem(inventory.getSize()-1);
+        if(pager != null
+                && !pager.getType().isAir()
+                && pager.hasItemMeta()
+                && pager.getItemMeta().hasLocalizedName())
+        {
+            String[] data = pager.getItemMeta().getLocalizedName().split(";");
+            if(data.length != 3)
+                return -1;
+
+            String tag = data[0];
+            if(!tag.equalsIgnoreCase("MCPetsPage"))
+                return -1;
+
+            String page = data[2];
+            return Integer.parseInt(page);
+        }
+        return -1;
+    }
+
     public static void add(Category category)
     {
         categories.add(category);
+    }
+
+    /**
+     * Return the category associated to the said id
+     * null if none is found
+     * @param categoryId
+     * @return
+     */
+    public static Category getFromId(String categoryId)
+    {
+        Optional<Category> optional = categories.stream().filter(cat -> cat.getId().equals(categoryId)).findFirst();
+        return optional.orElse(null);
+    }
+
+    /**
+     * Return the category associated to the said inventory
+     * null if none is found
+     * @param inventory
+     * @return
+     */
+    public static Category getFromInventory(Inventory inventory)
+    {
+        if(inventory == null)
+            return null;
+
+        ItemStack pager = inventory.getItem(inventory.getSize()-1);
+        if(pager != null
+                && !pager.getType().isAir()
+                && pager.hasItemMeta()
+                && pager.getItemMeta().hasLocalizedName())
+        {
+            String[] data = pager.getItemMeta().getLocalizedName().split(";");
+            if(data.length != 3)
+                return null;
+
+            String tag = data[0];
+            if(!tag.equalsIgnoreCase("MCPetsPage"))
+                return null;
+
+            String categoryId = data[1];
+            String page = data[2];
+
+            return getFromId(categoryId);
+        }
+        return null;
     }
 
 }

--- a/src/main/java/fr/nocsy/mcpets/data/Items.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Items.java
@@ -16,7 +16,8 @@ public enum Items {
 
     MOUNT("mount"),
     RENAME("rename"),
-    PETMENU("petmenu");
+    PETMENU("petmenu"),
+    UNKNOWN("unkown");
 
     @Getter
     private ItemStack item;
@@ -37,12 +38,29 @@ public enum Items {
             case "petmenu":
                 item = petmenu();
                 break;
+            default:
+                item = unknown();
         }
     }
 
     public void setItem(ItemStack item)
     {
         this.item = item;
+    }
+
+    private static ItemStack unknown()
+    {
+        ArrayList<String> lore = new ArrayList<>();
+
+        ItemStack it = Utils.createHead("Unknown",
+                lore,
+                "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzhmM2Q3NjkxZDZkNWQ1NDZjM2NmMjIyNDNiM2U4MzA5YTEwNzAxMWYyZWU5Mzg0OGIxZThjNjU3NjgxYTU2ZCJ9fX0=");
+        ItemMeta meta = it.getItemMeta();
+        meta.setLocalizedName("AlmPet;Unknown");
+
+        it.setItemMeta(meta);
+
+        return it;
     }
 
     private static ItemStack mount() {
@@ -139,7 +157,39 @@ public enum Items {
         return it != null &&
                 it.hasItemMeta() &&
                 it.getItemMeta().hasLocalizedName() &&
-                it.getItemMeta().getLocalizedName().equals(Pet.SIGNAL_STICK_TAG);
+                it.getItemMeta().getLocalizedName().contains(Pet.SIGNAL_STICK_TAG);
+    }
+
+    public static ItemStack turnIntoSignalStick(ItemStack it, Pet pet)
+    {
+        if(it == null ||
+                it.getType().isAir() ||
+                pet == null)
+            return it;
+        ItemMeta meta = it.getItemMeta();
+        meta.setLocalizedName(buildSignalStickTag(pet));
+        it.setItemMeta(meta);
+        return it;
+    }
+
+    public static String buildSignalStickTag(Pet pet)
+    {
+        if(pet == null)
+            return null;
+        return Pet.SIGNAL_STICK_TAG + ";" + pet.getId();
+    }
+
+    public static String getPetTag(ItemStack it)
+    {
+        if(it != null &&
+            it.hasItemMeta() &&
+            it.getItemMeta().hasLocalizedName())
+        {
+            String[] split = it.getItemMeta().getLocalizedName().split(";");
+            if(split.length == 2)
+                return split[1];
+        }
+        return null;
     }
 
 }

--- a/src/main/java/fr/nocsy/mcpets/data/Items.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Items.java
@@ -1,6 +1,7 @@
 package fr.nocsy.mcpets.data;
 
 import fr.nocsy.mcpets.data.config.FormatArg;
+import fr.nocsy.mcpets.data.config.ItemsListConfig;
 import fr.nocsy.mcpets.data.config.Language;
 import fr.nocsy.mcpets.utils.Utils;
 import lombok.Getter;
@@ -21,6 +22,11 @@ public enum Items {
     private ItemStack item;
 
     Items(String name) {
+        if(ItemsListConfig.getInstance().getItemStack(name) != null)
+        {
+            item = ItemsListConfig.getInstance().getItemStack(name);
+            return;
+        }
         switch (name) {
             case "mount":
                 item = mount();
@@ -29,12 +35,18 @@ public enum Items {
                 item = rename();
                 break;
             case "petmenu":
-                item = backToPets();
+                item = petmenu();
                 break;
         }
     }
 
+    public void setItem(ItemStack item)
+    {
+        this.item = item;
+    }
+
     private static ItemStack mount() {
+
         ItemStack it = new ItemStack(Material.SADDLE);
         ItemMeta meta = it.getItemMeta();
         meta.setDisplayName(Language.MOUNT_ITEM_NAME.getMessage());
@@ -58,7 +70,7 @@ public enum Items {
         return it;
     }
 
-    private static ItemStack backToPets() {
+    private static ItemStack petmenu() {
         ArrayList<String> lore = new ArrayList<>(Arrays.asList(Language.BACK_TO_PETMENU_ITEM_DESCRIPTION.getMessage().split("\n")));
 
         ItemStack it = Utils.createHead(Language.BACK_TO_PETMENU_ITEM_NAME.getMessage(), lore, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTI5M2E2MDcwNTAzMTcyMDcxZjM1ZjU4YzgyMjA0ZTgxOGNkMDY1MTg2OTAxY2ExOWY3ZGFkYmRhYzE2NWU0NCJ9fX0=");
@@ -124,7 +136,10 @@ public enum Items {
     }
 
     public static boolean isSignalStick(ItemStack it) {
-        return it != null && it.hasItemMeta() && it.getItemMeta().hasLocalizedName() && it.getItemMeta().getLocalizedName().equals(Pet.SIGNAL_STICK_TAG);
+        return it != null &&
+                it.hasItemMeta() &&
+                it.getItemMeta().hasLocalizedName() &&
+                it.getItemMeta().getLocalizedName().equals(Pet.SIGNAL_STICK_TAG);
     }
 
 }

--- a/src/main/java/fr/nocsy/mcpets/data/Items.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Items.java
@@ -103,11 +103,30 @@ public enum Items {
     public static ItemStack page(int index) {
         ItemStack it = new ItemStack(Material.PAPER);
         ItemMeta meta = it.getItemMeta();
+        meta.setCustomModelData(960);
         meta.setDisplayName(Language.TURNPAGE_ITEM_NAME.getMessage());
 
         meta.setLocalizedName("AlmPetPage;" + index);
 
         ArrayList<String> lore = new ArrayList<>(Arrays.asList(Language.TURNPAGE_ITEM_DESCRIPTION.getMessage().split("\n")));
+        meta.setLore(lore);
+
+        it.setItemMeta(meta);
+        return it;
+    }
+
+    public static ItemStack page(Category category, int index) {
+        ItemStack it = new ItemStack(Material.PAPER);
+        ItemMeta meta = it.getItemMeta();
+        meta.setCustomModelData(960);
+        meta.setDisplayName(Language.TURNPAGE_ITEM_NAME.getMessageFormatted(new FormatArg("currentPage", Integer.toString(index)),
+                                                                            new FormatArg("maxPage", Integer.toString(category.getMaxPages()))));
+        meta.setLocalizedName("MCPetsPage;" + category.getId() + ";" + index);
+
+        ArrayList<String> lore = new ArrayList<>(Arrays.asList(Language.TURNPAGE_ITEM_DESCRIPTION.getMessageFormatted(
+                                                        new FormatArg("currentPage", Integer.toString(index)),
+                                                        new FormatArg("maxPage", Integer.toString(category.getMaxPages())))
+                                                        .split("\n")));
         meta.setLore(lore);
 
         it.setItemMeta(meta);

--- a/src/main/java/fr/nocsy/mcpets/data/Items.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Items.java
@@ -6,6 +6,7 @@ import fr.nocsy.mcpets.data.config.Language;
 import fr.nocsy.mcpets.utils.Utils;
 import lombok.Getter;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -151,11 +152,12 @@ public enum Items {
         return it;
     }
 
-    public static ItemStack page(int index) {
+    public static ItemStack page(int index, Player p) {
         ItemStack it = new ItemStack(Material.PAPER);
         ItemMeta meta = it.getItemMeta();
         meta.setCustomModelData(960);
-        meta.setDisplayName(Language.TURNPAGE_ITEM_NAME.getMessage());
+        meta.setDisplayName(Language.TURNPAGE_ITEM_NAME.getMessageFormatted(new FormatArg("%currentPage%", Integer.toString(index+1)),
+                                                                            new FormatArg("%maxPage%", Integer.toString((int)(Pet.getAvailablePets(p).size()/54 + 0.5)))));
 
         meta.setLocalizedName("AlmPetPage;" + index);
 
@@ -170,13 +172,13 @@ public enum Items {
         ItemStack it = new ItemStack(Material.PAPER);
         ItemMeta meta = it.getItemMeta();
         meta.setCustomModelData(960);
-        meta.setDisplayName(Language.TURNPAGE_ITEM_NAME.getMessageFormatted(new FormatArg("currentPage", Integer.toString(index)),
-                                                                            new FormatArg("maxPage", Integer.toString(category.getMaxPages()))));
+        meta.setDisplayName(Language.TURNPAGE_ITEM_NAME.getMessageFormatted(new FormatArg("%currentPage%", Integer.toString(index+1)),
+                                                                            new FormatArg("%maxPage%", Integer.toString(category.getMaxPages()))));
         meta.setLocalizedName("MCPetsPage;" + category.getId() + ";" + index);
 
         ArrayList<String> lore = new ArrayList<>(Arrays.asList(Language.TURNPAGE_ITEM_DESCRIPTION.getMessageFormatted(
-                                                        new FormatArg("currentPage", Integer.toString(index)),
-                                                        new FormatArg("maxPage", Integer.toString(category.getMaxPages())))
+                                                        new FormatArg("%currentPage%", Integer.toString(index)),
+                                                        new FormatArg("%maxPage%", Integer.toString(category.getMaxPages())))
                                                         .split("\n")));
         meta.setLore(lore);
 

--- a/src/main/java/fr/nocsy/mcpets/data/Items.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Items.java
@@ -17,6 +17,9 @@ public enum Items {
     MOUNT("mount"),
     RENAME("rename"),
     PETMENU("petmenu"),
+    INVENTORY("inventory"),
+    SKINS("skins"),
+    EQUIPMENT("equipment"),
     UNKNOWN("unkown");
 
     @Getter
@@ -37,6 +40,15 @@ public enum Items {
                 break;
             case "petmenu":
                 item = petmenu();
+                break;
+            case "inventory":
+                item = inventory();
+                break;
+            case "skins":
+                item = skins();
+                break;
+            case "equipment":
+                item = equipment();
                 break;
             default:
                 item = unknown();
@@ -94,6 +106,45 @@ public enum Items {
         ItemStack it = Utils.createHead(Language.BACK_TO_PETMENU_ITEM_NAME.getMessage(), lore, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTI5M2E2MDcwNTAzMTcyMDcxZjM1ZjU4YzgyMjA0ZTgxOGNkMDY1MTg2OTAxY2ExOWY3ZGFkYmRhYzE2NWU0NCJ9fX0=");
         ItemMeta meta = it.getItemMeta();
         meta.setLocalizedName("AlmPet;BackToPetMenu");
+
+        it.setItemMeta(meta);
+
+        return it;
+    }
+
+    private static ItemStack inventory() {
+        ArrayList<String> lore = new ArrayList<>(Arrays.asList(Language.INVENTORY_ITEM_DESCRIPTION.getMessage().split("\n")));
+
+        ItemStack it = new ItemStack(Material.CHEST);
+        ItemMeta meta = it.getItemMeta();
+        meta.setDisplayName(Language.INVENTORY_ITEM_NAME.getMessage());
+        meta.setLocalizedName("AlmPet;Inventory");
+
+        it.setItemMeta(meta);
+
+        return it;
+    }
+
+    private static ItemStack skins() {
+        ArrayList<String> lore = new ArrayList<>(Arrays.asList(Language.SKINS_ITEM_DESCRIPTION.getMessage().split("\n")));
+
+        ItemStack it = new ItemStack(Material.MAGMA_CREAM);
+        ItemMeta meta = it.getItemMeta();
+        meta.setDisplayName(Language.SKINS_ITEM_NAME.getMessage());
+        meta.setLocalizedName("AlmPet;Skins");
+
+        it.setItemMeta(meta);
+
+        return it;
+    }
+
+    private static ItemStack equipment() {
+        ArrayList<String> lore = new ArrayList<>(Arrays.asList(Language.EQUIPMENT_ITEM_NAME.getMessage().split("\n")));
+
+        ItemStack it = new ItemStack(Material.LEATHER_HORSE_ARMOR);
+        ItemMeta meta = it.getItemMeta();
+        meta.setDisplayName(Language.EQUIPMENT_ITEM_NAME.getMessage());
+        meta.setLocalizedName("AlmPet;Inventory");
 
         it.setItemMeta(meta);
 

--- a/src/main/java/fr/nocsy/mcpets/data/Pet.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Pet.java
@@ -119,6 +119,10 @@ public class Pet {
 
     @Getter
     @Setter
+    private int inventorySize;
+
+    @Getter
+    @Setter
     private List<String> signals;
 
     @Getter
@@ -742,6 +746,7 @@ public class Pet {
         pet.setDespawnSkill(despawnSkill);
         pet.setMountable(mountable);
         pet.setMountType(mountType);
+        pet.setInventorySize(inventorySize);
         pet.setAutoRide(autoRide);
         pet.setIcon(icon);
         pet.setSignalStick(signalStick);

--- a/src/main/java/fr/nocsy/mcpets/data/Pet.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Pet.java
@@ -277,6 +277,15 @@ public class Pet {
     }
 
     /**
+     * Associate the said player to the pet as last interacted with
+     * @param p
+     */
+    public void setLastInteractedWith(Player p)
+    {
+        p.setMetadata("AlmPetInteracted", new FixedMetadataValue(MCPets.getInstance(), this));
+    }
+
+    /**
      * Return the pet from the signal stick item
      * null if none is found matching the id
      * @param signalStick
@@ -579,6 +588,7 @@ public class Pet {
      */
     public int spawn(@NotNull Player owner, Location loc) {
         this.owner = owner.getUniqueId();
+        setLastInteractedWith(owner);
         return spawn(loc);
     }
 

--- a/src/main/java/fr/nocsy/mcpets/data/Pet.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Pet.java
@@ -38,7 +38,7 @@ public class Pet {
     public static final String SIGNAL_STICK_TAG = "&MCPets-SignalSticks&";
 
     //---------------------------------------------------------------------
-    public static final int BLOCKED = 1;
+    public static final int BLOCKED = 2;
     public static final int MOB_SPAWN = 0;
     public static final int DESPAWNED_PREVIOUS = 1;
     public static final int OWNER_NULL = -1;
@@ -617,7 +617,7 @@ public class Pet {
         if (ownerPlayer != null) {
             if (reason.equals(PetDespawnReason.UNKNOWN) ||
                     reason.equals(PetDespawnReason.SPAWN_ISSUE)) {
-                Language.REVOKED.sendMessage(ownerPlayer);
+                Language.REVOKED_UNKNOWN.sendMessage(ownerPlayer);
             }
         }
 
@@ -921,6 +921,15 @@ public class Pet {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Says whether or not the pet has skins
+     * @return
+     */
+    public boolean hasSkins()
+    {
+        return PetSkin.getSkins(this) != null && PetSkin.getSkins(this).size() > 0;
     }
 
     /**

--- a/src/main/java/fr/nocsy/mcpets/data/Pet.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Pet.java
@@ -664,6 +664,11 @@ public class Pet {
                 !removed;
     }
 
+    public boolean has(Player p)
+    {
+        return p.hasPermission(this.getPermission());
+    }
+
     /**
      * Set the display name of the pet
      */

--- a/src/main/java/fr/nocsy/mcpets/data/PetDespawnReason.java
+++ b/src/main/java/fr/nocsy/mcpets/data/PetDespawnReason.java
@@ -8,6 +8,7 @@ public enum PetDespawnReason {
     DEATH("death"),
     REVOKE("revoke"),
     REPLACED("replaced"),
+    SETPET_REPLACED("setpet replaced"),
     OWNER_NOT_HERE("owner not here"),
     RELOAD("reload"),
     FLAG("flag"),

--- a/src/main/java/fr/nocsy/mcpets/data/PetSkin.java
+++ b/src/main/java/fr/nocsy/mcpets/data/PetSkin.java
@@ -1,0 +1,231 @@
+package fr.nocsy.mcpets.data;
+
+import com.ticxo.modelengine.api.ModelEngineAPI;
+import com.ticxo.modelengine.api.model.ActiveModel;
+import com.ticxo.modelengine.api.model.ModeledEntity;
+import com.ticxo.modelengine.model.MEActiveModel;
+import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.config.FormatArg;
+import fr.nocsy.mcpets.data.config.Language;
+import lombok.Getter;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.metadata.FixedMetadataValue;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class PetSkin {
+
+    private static HashMap<String, ArrayList<PetSkin>> petSkins = new HashMap<>();
+
+    @Getter
+    private String uuid;
+
+    @Getter
+    private Pet objectPet;
+    @Getter
+    private String modelSkinId;
+    @Getter
+    private ItemStack icon;
+    @Getter
+    private String permission;
+
+    private PetSkin(Pet objectPet, String modelSkinId, String permission)
+    {
+        this.uuid = UUID.randomUUID().toString();
+
+        this.objectPet = objectPet;
+        this.modelSkinId = modelSkinId;
+        this.permission = permission;
+        initIcon();
+    }
+
+    /**
+     * Load the PetSkin object in the cache
+     * @param objectPet
+     * @param modelSkinId
+     * @param icon
+     */
+    public static void load(Pet objectPet, String modelSkinId, String permission, ItemStack icon)
+    {
+        PetSkin petSkin = new PetSkin(objectPet, modelSkinId, permission);
+        petSkin.setIcon(icon);
+
+        ArrayList<PetSkin> listSkins = petSkins.get(objectPet.getId());
+        if(listSkins == null)
+            listSkins = new ArrayList<>();
+
+        listSkins.add(petSkin);
+        petSkins.put(objectPet.getId(), listSkins);
+    }
+
+    /**
+     * Fetch the PetSkin from the icon
+     * @param it
+     * @return
+     */
+    public static PetSkin fromIcon(ItemStack it)
+    {
+        if(it.hasItemMeta() &&
+            it.getItemMeta().hasLocalizedName())
+        {
+            String[] code = it.getItemMeta().getLocalizedName().split(";");
+            if(code.length > 0 && code[0].equals("MCPetsSkins"))
+            {
+                String petId = code[1];
+                String skinUuid = code[2];
+                ArrayList<PetSkin> skins = petSkins.get(petId);
+                if(skins != null)
+                {
+                    Optional<PetSkin> opt = skins.stream().filter(petSkin -> petSkin.getUuid().equals(skinUuid)).findFirst();
+                    return opt.orElse(null);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Fetch all skins from the pet
+     * @param pet
+     * @return
+     */
+    public static ArrayList<PetSkin> getSkins(Pet pet)
+    {
+        return petSkins.get(pet.getId());
+    }
+
+    /**
+     * Open the pet skins to the player
+     * @param p
+     * @param pet
+     * @return
+     */
+    public static boolean openInventory(Player p, Pet pet)
+    {
+        if(pet == null)
+            return false;
+
+        List<PetSkin> skins = petSkins.get(pet.getId());
+        if(skins == null || skins.size() == 0)
+            return false;
+
+        skins = skins.stream().filter(petSkin -> p.hasPermission(petSkin.getPermission())).collect(Collectors.toList());
+
+        int invSize = Math.min(skins.size(), 54);
+        while(invSize <= 0 || invSize%9 != 0)
+            invSize++;
+
+        Inventory inventory = Bukkit.createInventory(null, invSize, Language.PET_SKINS_TITLE.getMessageFormatted(new FormatArg("%pet%", pet.getIcon().getItemMeta().getDisplayName())));
+
+        for(PetSkin petSkin : skins)
+        {
+            inventory.addItem(petSkin.getIcon());
+        }
+
+        p.openInventory(inventory);
+        addMetada(p);
+        return true;
+    }
+
+    /**
+     * Add metadata to handle GUI
+     * @param p
+     */
+    private static void addMetada(Player p)
+    {
+        p.setMetadata("MCPetsSkins", new FixedMetadataValue(MCPets.getInstance(), "opened"));
+    }
+
+    /**
+     * Remove the metadata to handle GUI
+     * @param p
+     */
+    public static void removeMetadata(Player p)
+    {
+        p.setMetadata("MCPetsSkins", new FixedMetadataValue(MCPets.getInstance(), null));
+    }
+
+    /**
+     * Clear previous entries
+     */
+    public static void clearList()
+    {
+        petSkins.clear();
+    }
+
+    /**
+     * Check if the player has the skins metadata
+     * @param p
+     * @return
+     */
+    public static boolean hasMetadata(Player p)
+    {
+        return !p.getMetadata("MCPetsSkins").isEmpty() &&
+                p.getMetadata("MCPetsSkins").get(0) != null &&
+                p.getMetadata("MCPetsSkins").get(0).value() != null;
+    }
+
+    /**
+     * Set the petSkin icon
+     * @param icon
+     */
+    private void setIcon(ItemStack icon)
+    {
+        if (icon != null)
+        {
+            this.icon = icon;
+            prepareIcon();
+        }
+    }
+    /**
+     * Initialize the icon
+     */
+    private void initIcon()
+    {
+        icon = Items.UNKNOWN.getItem();
+        ItemMeta meta = icon.getItemMeta();
+        meta.setDisplayName("§6Skin §7: " + modelSkinId);
+        ArrayList<String> lore = new ArrayList<>();
+        lore.add("§7Click to apply that skin");
+        meta.setLore(lore);
+        icon.setItemMeta(meta);
+        prepareIcon();
+    }
+
+    /**
+     * Add the required localized name to the icon so we can identify it later on
+     */
+    private void prepareIcon()
+    {
+        ItemMeta meta = icon.getItemMeta();
+        meta.setLocalizedName("MCPetsSkins;" + objectPet.getId() + ";" + uuid);
+        icon.setItemMeta(meta);
+    }
+
+    /**
+     * Apply the skin to the pet
+     * @param instancePet
+     */
+    public boolean apply(Pet instancePet)
+    {
+        if(!instancePet.isStillHere())
+            return false;
+
+        if(!instancePet.getId().equals(objectPet.getId()))
+            return false;
+
+        ModeledEntity ent = ModelEngineAPI.getModeledEntity(instancePet.getActiveMob().getEntity().getUniqueId());
+        if (ent != null) {
+            ent.getAllActiveModel().keySet().forEach(ent::removeModel);
+            ent.addActiveModel((ActiveModel) new MEActiveModel(modelSkinId));
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/fr/nocsy/mcpets/data/config/CategoryConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/CategoryConfig.java
@@ -41,6 +41,7 @@ public class CategoryConfig extends AbstractConfig {
     public void init(String folderName, String fileName) {
         super.init(folderName, fileName);
 
+        this.id = fileName.replace(".yml", "");
         this.category = new Category(id);
 
         if (getConfig().get("DisplayName") == null)
@@ -64,6 +65,7 @@ public class CategoryConfig extends AbstractConfig {
 
         loadConfig();
 
+        category.getPets().clear();
 
         if (getConfig().get("DisplayName") != null)
         {
@@ -117,7 +119,7 @@ public class CategoryConfig extends AbstractConfig {
                 continue;
             }
 
-            CategoryConfig config = new CategoryConfig(folder.getPath().replace("\\", "/").replace(AbstractConfig.getPath(), ""), file.getName().replace(".yml", ""));
+            CategoryConfig config = new CategoryConfig(folder.getPath().replace("\\", "/").replace(AbstractConfig.getPath(), ""), file.getName());
 
             if (config.getCategory() != null)
                 Category.add(config.getCategory());

--- a/src/main/java/fr/nocsy/mcpets/data/config/CategoryConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/CategoryConfig.java
@@ -1,0 +1,139 @@
+package fr.nocsy.mcpets.data.config;
+
+import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.Category;
+import fr.nocsy.mcpets.data.Items;
+import fr.nocsy.mcpets.data.Pet;
+import lombok.Getter;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.checkerframework.checker.units.qual.C;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Comparator;
+
+public class CategoryConfig extends AbstractConfig {
+
+    @Getter
+    private String id;
+
+    @Getter
+    private Category category;
+
+    public CategoryConfig(String id)
+    {
+        super();
+        if(id != null && !id.isEmpty())
+            this.id = id;
+    }
+    /**
+     * Base constructor of a pet configuration (one to one)
+     * It will initialize the variables while loading the data
+     *
+     * @param fileName
+     */
+    public CategoryConfig(String folderName, String fileName) {
+        init(folderName, fileName);
+        reload();
+    }
+
+    @Override
+    public void init(String folderName, String fileName) {
+        super.init(folderName, fileName);
+
+        this.category = new Category(id);
+
+        if (getConfig().get("DisplayName") == null)
+            getConfig().set("DisplayName", "Category");
+        if (getConfig().get("Icon") == null)
+            getConfig().set("Icon", setupUnkownIcon());
+        if (getConfig().get("Pets") == null)
+            getConfig().set("Pets", new ArrayList<>());
+
+        save();
+        reload();
+    }
+
+    @Override
+    public void save() {
+        super.save();
+    }
+
+    @Override
+    public void reload() {
+
+        loadConfig();
+
+
+        if (getConfig().get("DisplayName") != null)
+        {
+            category.setDisplayName(getConfig().getString("DisplayName"));
+        }
+        if (getConfig().get("Pets") != null)
+        {
+            for(String id : getConfig().getStringList("Pets"))
+            {
+                Pet pet = Pet.getFromId(id);
+                if(pet != null)
+                    category.addPet(pet);
+            }
+        }
+        if (getConfig().get("Icon") != null)
+        {
+            category.setIcon((getConfig().getItemStack("Icon")));
+        }
+
+    }
+
+    private ItemStack setupUnkownIcon()
+    {
+        ItemStack it = Items.UNKNOWN.getItem();
+        ItemMeta meta = it.getItemMeta();
+        meta.setLocalizedName("MCPets;" + id);
+        meta.setDisplayName("§6" + id);
+        it.setItemMeta(meta);
+        return it;
+    }
+
+    /**
+     * Load all the existing categories
+     *
+     * @param folderPath : folder where to seek for the pets
+     * @param clear  : whether or not the loaded ones should be cleared (only first call should do that)
+     */
+    public static void load(String folderPath, boolean clear) {
+        if (clear) {
+            Category.getCategories().clear();
+        }
+
+        File folder = new File(folderPath);
+        if (!folder.exists())
+            folder.mkdirs();
+
+        for (File file : folder.listFiles()) {
+            if (file.isDirectory()) {
+                load(file.getPath().replace("\\", "/"), false);
+                continue;
+            }
+
+            CategoryConfig config = new CategoryConfig(folder.getPath().replace("\\", "/").replace(AbstractConfig.getPath(), ""), file.getName().replace(".yml", ""));
+
+            if (config.getCategory() != null)
+                Category.add(config.getCategory());
+
+        }
+
+
+        Category.getCategories().sort(new Comparator<Category>() {
+            @Override
+            public int compare(Category o1, Category o2) {
+                return o1.getId().compareTo(o2.getId());
+            }
+        });
+
+        if (clear)
+            MCPets.getLog().info(MCPets.getLogName() + Category.getCategories().size() + " categories registered successfully !");
+    }
+
+}

--- a/src/main/java/fr/nocsy/mcpets/data/config/CategoryConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/CategoryConfig.java
@@ -7,7 +7,6 @@ import fr.nocsy.mcpets.data.Pet;
 import lombok.Getter;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.checkerframework.checker.units.qual.C;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -78,6 +77,7 @@ public class CategoryConfig extends AbstractConfig {
                 if(pet != null)
                     category.addPet(pet);
             }
+            category.countMaxPages();
         }
         if (getConfig().get("Icon") != null)
         {

--- a/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
@@ -3,7 +3,9 @@ package fr.nocsy.mcpets.data.config;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 public class GlobalConfig extends AbstractConfig {
 
@@ -28,6 +30,8 @@ public class GlobalConfig extends AbstractConfig {
     @Getter
     private boolean leftClickToOpen;
     @Getter
+    private boolean disableInventoryWhileHoldingSignalStick;
+    @Getter
     private boolean sneakMode;
     @Getter
     private boolean dismountOnDamaged;
@@ -51,6 +55,8 @@ public class GlobalConfig extends AbstractConfig {
     private String MySQL_PORT;
     @Getter
     private String MySQL_DB;
+    @Getter
+    private List<String> blackListedWorlds;
 
     @Getter
     @Setter
@@ -74,6 +80,8 @@ public class GlobalConfig extends AbstractConfig {
             getConfig().set("RightClickToOpenMenu", true);
         if (getConfig().get("LeftClickToOpenMenu") == null)
             getConfig().set("LeftClickToOpenMenu", true);
+        if (getConfig().get("DisableInventoryWhileHoldingSignalStick") == null)
+            getConfig().set("DisableInventoryWhileHoldingSignalStick", true);
         if (getConfig().get("DismountOnDamaged") == null)
             getConfig().set("DismountOnDamaged", true);
         if (getConfig().get("SpawnPetOnReconnect") == null)
@@ -104,6 +112,8 @@ public class GlobalConfig extends AbstractConfig {
             getConfig().set("MySQL.Port", "2560");
         if (getConfig().get("MySQL.Database") == null)
             getConfig().set("MySQL.Database", "advancedpet_db");
+        if(getConfig().get("BlackListedWorlds") == null)
+            getConfig().set("BlackListedWorlds", new ArrayList<String>());
 
         save();
         reload();
@@ -123,6 +133,7 @@ public class GlobalConfig extends AbstractConfig {
         defaultName = getConfig().getString("DefaultName");
         rightClickToOpen = getConfig().getBoolean("RightClickToOpenMenu");
         leftClickToOpen = getConfig().getBoolean("LeftClickToOpenMenu");
+        disableInventoryWhileHoldingSignalStick = getConfig().getBoolean("DisableInventoryWhileHoldingSignalStick");
         sneakMode = getConfig().getBoolean("SneakMode");
         nameable = getConfig().getBoolean("Nameable");
         mountable = getConfig().getBoolean("Mountable");
@@ -148,7 +159,12 @@ public class GlobalConfig extends AbstractConfig {
         MySQL_HOST = getConfig().getString("MySQL.Host");
         MySQL_PORT = getConfig().getString("MySQL.Port");
         MySQL_DB = getConfig().getString("MySQL.Database");
+        blackListedWorlds = getConfig().getStringList("BlackListedWorlds");
+    }
 
+    public boolean hasBlackListedWorld(String worldName)
+    {
+        return blackListedWorlds.contains(worldName);
     }
 
 }

--- a/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
@@ -16,7 +16,7 @@ public class GlobalConfig extends AbstractConfig {
     private boolean worldguardsupport = true;
 
     @Getter
-    private String prefix = "§8[§6MCPets§8] »";
+    private String prefix = "§8[§6MCPets§8] » ";
     @Getter
     private String defaultName = "§9Pet of %player%";
     @Getter

--- a/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
@@ -22,6 +22,8 @@ public class GlobalConfig extends AbstractConfig {
     @Getter
     private int adaptiveInventory = -1;
     @Getter
+    private boolean useDefaultMythicMobNames;
+    @Getter
     private boolean nameable;
     @Getter
     private boolean mountable;
@@ -76,6 +78,8 @@ public class GlobalConfig extends AbstractConfig {
             getConfig().set("Prefix", prefix);
         if (getConfig().get("DefaultName") == null)
             getConfig().set("DefaultName", defaultName);
+        if (getConfig().get("UseDefaultMythicMobsNames") == null)
+            getConfig().set("UseDefaultMythicMobsNames", false);
         if (getConfig().get("RightClickToOpenMenu") == null)
             getConfig().set("RightClickToOpenMenu", true);
         if (getConfig().get("LeftClickToOpenMenu") == null)
@@ -131,6 +135,7 @@ public class GlobalConfig extends AbstractConfig {
 
         prefix = getConfig().getString("Prefix");
         defaultName = getConfig().getString("DefaultName");
+        useDefaultMythicMobNames = getConfig().getBoolean("UseDefaultMythicMobsNames");
         rightClickToOpen = getConfig().getBoolean("RightClickToOpenMenu");
         leftClickToOpen = getConfig().getBoolean("LeftClickToOpenMenu");
         disableInventoryWhileHoldingSignalStick = getConfig().getBoolean("DisableInventoryWhileHoldingSignalStick");

--- a/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
@@ -3,6 +3,8 @@ package fr.nocsy.mcpets.data.config;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.HashMap;
+
 public class GlobalConfig extends AbstractConfig {
 
     public static GlobalConfig instance;
@@ -38,6 +40,8 @@ public class GlobalConfig extends AbstractConfig {
     @Getter
     private boolean activateBackMenuIcon = true;
     @Getter
+    private boolean disableMySQL = false;
+    @Getter
     private String MySQL_USER;
     @Getter
     private String MySQL_PASSWORD;
@@ -53,7 +57,6 @@ public class GlobalConfig extends AbstractConfig {
     private boolean databaseSupport = false;
 
     public static GlobalConfig getInstance() {
-
         if (instance == null)
             instance = new GlobalConfig();
 
@@ -89,6 +92,8 @@ public class GlobalConfig extends AbstractConfig {
             getConfig().set("InventorySize", -1);
         if (getConfig().get("ActivateBackMenuIcon") == null)
             getConfig().set("ActivateBackMenuIcon", activateBackMenuIcon);
+        if (getConfig().get("DisableMySQL") == null)
+            getConfig().set("DisableMySQL", disableMySQL);
         if (getConfig().get("MySQL.User") == null)
             getConfig().set("MySQL.User", "user");
         if (getConfig().get("MySQL.Password") == null)
@@ -137,6 +142,7 @@ public class GlobalConfig extends AbstractConfig {
         while (adaptiveInventory > 0 && adaptiveInventory % 9 != 0 && adaptiveInventory < 54)
             adaptiveInventory++;
 
+        disableMySQL = getConfig().getBoolean("DisableMySQL");
         MySQL_USER = getConfig().getString("MySQL.User");
         MySQL_PASSWORD = getConfig().getString("MySQL.Password");
         MySQL_HOST = getConfig().getString("MySQL.Host");

--- a/src/main/java/fr/nocsy/mcpets/data/config/ItemsListConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/ItemsListConfig.java
@@ -1,0 +1,87 @@
+package fr.nocsy.mcpets.data.config;
+
+import fr.nocsy.mcpets.data.Items;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.Set;
+
+public class ItemsListConfig extends AbstractConfig {
+
+    private static ItemsListConfig instance;
+
+    private HashMap<String, ItemStack> items;
+
+    public ItemsListConfig()
+    {
+        items = new HashMap<>();
+    }
+
+    public static ItemsListConfig getInstance() {
+        if (instance == null)
+            instance = new ItemsListConfig();
+        return instance;
+    }
+
+    public void init() {
+        super.init("", "menuIcons.yml");
+
+        if (getConfig().get("mount") == null)
+            getConfig().set("mount", Items.MOUNT.getItem());
+        if (getConfig().get("rename") == null)
+            getConfig().set("rename", Items.RENAME.getItem());
+        if (getConfig().get("petmenu") == null)
+            getConfig().set("petmenu", Items.PETMENU.getItem());
+
+        save();
+        reload();
+    }
+
+    @Override
+    public void save() {
+        super.save();
+    }
+
+    @Override
+    public void reload() {
+
+        loadConfig();
+
+        for(String key : getConfig().getKeys(false))
+        {
+            if(getConfig().getItemStack(key) != null)
+                items.put(key, getConfig().getItemStack(key));
+        }
+
+    }
+
+    /**
+     * Return the item with the said key
+     * null if it doesn't exist
+     * @param key
+     * @return
+     */
+    public ItemStack getItemStack(String key)
+    {
+        return items.get(key);
+    }
+
+    public void setItemStack(String key, ItemStack itemStack)
+    {
+        items.put(key, itemStack);
+        getConfig().set(key, itemStack);
+        save();
+    }
+
+    public void removeItemStack(String key)
+    {
+        getConfig().set(key, null);
+        save();
+    }
+
+    public Set<String> listKeys()
+    {
+        return items.keySet();
+    }
+
+}

--- a/src/main/java/fr/nocsy/mcpets/data/config/ItemsListConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/ItemsListConfig.java
@@ -32,6 +32,10 @@ public class ItemsListConfig extends AbstractConfig {
             getConfig().set("rename", Items.RENAME.getItem());
         if (getConfig().get("petmenu") == null)
             getConfig().set("petmenu", Items.PETMENU.getItem());
+        if (getConfig().get("skins") == null)
+            getConfig().set("skins", Items.SKINS.getItem());
+        if (getConfig().get("equipment") == null)
+            getConfig().set("equipment", Items.EQUIPMENT.getItem());
 
         save();
         reload();
@@ -75,6 +79,7 @@ public class ItemsListConfig extends AbstractConfig {
 
     public void removeItemStack(String key)
     {
+        items.remove(key);
         getConfig().set(key, null);
         save();
     }

--- a/src/main/java/fr/nocsy/mcpets/data/config/Language.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/Language.java
@@ -74,7 +74,7 @@ public enum Language {
             "\n§8   ... §areload " +
             "\n§8   ... §7(nothing here to open the GUI) " +
             "\n§8   ... §aopen §8<§7player§8>" +
-            "\n§8   ... §aspawn §8<§7id§8> <§7player§8> §atrue§8/§cfalse §7(check if the player have the permission to spawn the pet or not)" +
+            "\n§8   ... §aspawn §8<§7id§8> <§7player§8> §atrue§8/§cfalse §7(check if the player have the permission to spawn the pet or not) -s (set silent or not)" +
             "\n§8   ... §arevoke" +
             "\n§8   ... §aname" +
             "\n§8   ... §amount" +
@@ -106,7 +106,7 @@ public enum Language {
     }
 
     public void sendMessage(CommandSender sender) {
-        sender.sendMessage(GlobalConfig.getInstance().getPrefix() + " " + message);
+        sender.sendMessage(GlobalConfig.getInstance().getPrefix() + message);
     }
 
     public void sendMessageFormated(CommandSender sender, FormatArg... args) {

--- a/src/main/java/fr/nocsy/mcpets/data/config/Language.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/Language.java
@@ -18,7 +18,7 @@ public enum Language {
     BACK_TO_PETMENU_ITEM_NAME("§cBack to menu"),
     BACK_TO_PETMENU_ITEM_DESCRIPTION("§7Click to get back to the menu"),
 
-    TURNPAGE_ITEM_NAME("§6Next page"),
+    TURNPAGE_ITEM_NAME("§6Next page §7(§e%currentPage%/§7%maxPage%)"),
     TURNPAGE_ITEM_DESCRIPTION("§eRight click§7 to go forward \n§aLeft click§7 to go backward"),
 
     NICKNAME("§9Nickname : §7%nickname%"),
@@ -74,7 +74,8 @@ public enum Language {
     NO_PERM("§cYou're not allowed to use this command."),
     BLACKLISTED_WORLD("§cMCPets is disabled in this world."),
 
-    CATEGORY_PET_AMOUNT("§e%petamount% §6registered");
+    CATEGORY_PET_AMOUNT("§e%petamount% §6registered"),
+    CATEGORY_MENU_TITLE("§0☀ §4Pets §8- §0%category% §0☀");
 
     @Getter
     private String message;

--- a/src/main/java/fr/nocsy/mcpets/data/config/Language.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/Language.java
@@ -75,7 +75,9 @@ public enum Language {
     BLACKLISTED_WORLD("§cMCPets is disabled in this world."),
 
     CATEGORY_PET_AMOUNT("§e%petamount% §6registered"),
-    CATEGORY_MENU_TITLE("§0☀ §4Pets §8- §0%category% §0☀");
+    CATEGORY_MENU_TITLE("§0☀ §4Pets §8- §0%category% §0☀"),
+
+    PET_INVENTORY_TITLE("§0☀ §4%pet% §8- §0Inventory §0☀§");
 
     @Getter
     private String message;

--- a/src/main/java/fr/nocsy/mcpets/data/config/Language.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/Language.java
@@ -70,8 +70,11 @@ public enum Language {
             "\n§8   ... §aname" +
             "\n§8   ... §amount" +
             "\n§8   ... §aitem §7<§elist§8/§8add/§8§7remove> <key>" +
-            "\n§8   ... §asignalstick §7<§eplayer§7>"),
-    NO_PERM("§cYou're not allowed to use this command.");
+            "\n§8   ... §asignalstick §7<§eplayer§7> §7<§epet§7>"),
+    NO_PERM("§cYou're not allowed to use this command."),
+    BLACKLISTED_WORLD("§cMCPets is disabled in this world."),
+
+    CATEGORY_PET_AMOUNT("§e%petamount% §6registered");
 
     @Getter
     private String message;

--- a/src/main/java/fr/nocsy/mcpets/data/config/Language.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/Language.java
@@ -18,6 +18,15 @@ public enum Language {
     BACK_TO_PETMENU_ITEM_NAME("§cBack to menu"),
     BACK_TO_PETMENU_ITEM_DESCRIPTION("§7Click to get back to the menu"),
 
+    INVENTORY_ITEM_NAME("§6Inventory"),
+    INVENTORY_ITEM_DESCRIPTION("§7Click to open the pet's inventory"),
+
+    SKINS_ITEM_NAME("§6Skins"),
+    SKINS_ITEM_DESCRIPTION("§7Click to change your pet's skin"),
+
+    EQUIPMENT_ITEM_NAME("§6Equipment"),
+    EQUIPMENT_DESCRIPTION("§7Click to open your pet's equipment"),
+
     TURNPAGE_ITEM_NAME("§6Next page §7(§e%currentPage%/§7%maxPage%)"),
     TURNPAGE_ITEM_DESCRIPTION("§eRight click§7 to go forward \n§aLeft click§7 to go backward"),
 

--- a/src/main/java/fr/nocsy/mcpets/data/config/Language.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/Language.java
@@ -27,7 +27,7 @@ public enum Language {
     EQUIPMENT_ITEM_NAME("§6Equipment"),
     EQUIPMENT_DESCRIPTION("§7Click to open your pet's equipment"),
 
-    TURNPAGE_ITEM_NAME("§6Next page §7(§e%currentPage%/§7%maxPage%)"),
+    TURNPAGE_ITEM_NAME("§6Next page §7(§e%currentPage%§8/§7%maxPage%)"),
     TURNPAGE_ITEM_DESCRIPTION("§eRight click§7 to go forward \n§aLeft click§7 to go backward"),
 
     NICKNAME("§9Nickname : §7%nickname%"),
@@ -78,13 +78,13 @@ public enum Language {
             "\n§8   ... §arevoke" +
             "\n§8   ... §aname" +
             "\n§8   ... §amount" +
-            "\n§8   ... §aitem §7<§elist§8/§8add/§8§7remove> <key>" +
-            "\n§8   ... §asignalstick §7<§eplayer§7> §7<§epet§7>"),
+            "\n§8   ... §aitem §7<§elist§8/§eadd§8/§eremove§7> <§ekey§7>" +
+            "\n§8   ... §asignalstick §7<§eplayer§8/§epet§7> §7<§epet§7>"),
     NO_PERM("§cYou're not allowed to use this command."),
     BLACKLISTED_WORLD("§cMCPets is disabled in this world."),
 
-    CATEGORY_PET_AMOUNT("§e%petamount% §6registered"),
-    CATEGORY_MENU_TITLE("§0☀ §4Pets §8- §0%category% §0☀"),
+    CATEGORY_PET_AMOUNT("§e%petAmount% §6registered"),
+    CATEGORY_MENU_TITLE("§0☀ §4Pets §8- Pick a category §0☀"),
 
     PET_INVENTORY_TITLE("§0☀ §4%pet% §8- §0Inventory §0☀§");
 
@@ -102,7 +102,7 @@ public enum Language {
     }
 
     public void sendMessage(Player p) {
-        p.sendMessage(GlobalConfig.getInstance().getPrefix() + " " + message);
+        p.sendMessage(GlobalConfig.getInstance().getPrefix() + message);
     }
 
     public void sendMessage(CommandSender sender) {
@@ -114,7 +114,7 @@ public enum Language {
         for (FormatArg arg : args) {
             toSend = arg.applyToString(toSend);
         }
-        sender.sendMessage(GlobalConfig.getInstance().getPrefix() + " " + toSend);
+        sender.sendMessage(GlobalConfig.getInstance().getPrefix() + toSend);
     }
 
     public String getMessageFormatted(FormatArg... args) {

--- a/src/main/java/fr/nocsy/mcpets/data/config/Language.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/Language.java
@@ -36,6 +36,10 @@ public enum Language {
     SUMMONED("§7A pet has been summoned !"),
     REVOKED("§7Your pet was revoked."),
     REVOKED_FOR_NEW_ONE("§7Your previous pet was revoked to summon the new one."),
+    REVOKED_UNKNOWN("§cThe pet could not be spawned due to one of the following reasons :" +
+            "\n§7- The world is on §cpeaceful or easy mode§7." +
+            "\n§7- A region §cprevents the mob from spawning§7 (the anchor is an aggressive mob most likely)." +
+            "\n§7- You have a §cspawn protector plugin§7, try to spawn the mob in another world or far from spawn."),
     MYTHICMOB_NULL("§cThis pet could not be summoned. The associated mythicMob entity or file is null or was removed."),
     NO_MOB_MATCH("§cThis pet could not be summoned. The associated mythicmob isn't registered in MythicMobs."),
     NOT_ALLOWED("§cYou're not allowed to summon this pet."),
@@ -86,7 +90,12 @@ public enum Language {
     CATEGORY_PET_AMOUNT("§e%petAmount% §6registered"),
     CATEGORY_MENU_TITLE("§0☀ §4Pets §8- Pick a category §0☀"),
 
-    PET_INVENTORY_TITLE("§0☀ §4%pet% §8- §0Inventory §0☀§");
+    PET_INVENTORY_TITLE("§0☀ §4%pet% §8- §0Inventory §0☀§"),
+
+    PET_SKINS_TITLE("§0☀ §4%pet% §8- §0Skins §0☀§"),
+
+    SKIN_COULD_NOT_APPLY("§cThe skin could not be applied to the pet."),
+    SKIN_APPLIED("§aSkin changed successfully !");
 
     @Getter
     private String message;

--- a/src/main/java/fr/nocsy/mcpets/data/config/Language.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/Language.java
@@ -47,6 +47,14 @@ public enum Language {
     SIGNAL_STICK_GIVEN("§aYou've received an order stick. Right click to cast an order, left click to switch orders."),
     SIGNAL_STICK_SIGNAL("§6Active order : §e%signal%"),
     LOOP_SPAWN("§cYour pet was revoked because it seems to struggle with numerous teleportations."),
+    REQUIRES_ITEM_IN_HAND("§cYou must holding an item in your hand it update it in the config."),
+    ITEM_UPDATED("§aItem updated successful with the key : §e%key%"),
+    ITEM_DOESNT_EXIST("§aThe item with the key §e%key%§c doesn't exist. If you want to add it you can use the §eadd§c argument instead."),
+    KEY_DOESNT_EXIST("§cThe specified key is not registered."),
+    KEY_REMOVED("§aThe key item was removed succesfully."),
+    KEY_ALREADY_EXISTS("§cThis key is already registered. Use it to replace the current item."),
+    KEY_ADDED("§aKey added successfully with the corresponding item."),
+    KEY_LIST("§aAvailable keys :"),
 
     RELOAD_SUCCESS("§aReloaded successfully."),
     HOW_MANY_PETS_LOADED("§a%numberofpets% were registered successfully"),
@@ -60,7 +68,9 @@ public enum Language {
             "\n§8   ... §aspawn §8<§7id§8> <§7player§8> §atrue§8/§cfalse §7(check if the player have the permission to spawn the pet or not)" +
             "\n§8   ... §arevoke" +
             "\n§8   ... §aname" +
-            "\n§8   ... §amount"),
+            "\n§8   ... §amount" +
+            "\n§8   ... §aitem §7<§elist§8/§8add/§8§7remove> <key>" +
+            "\n§8   ... §asignalstick §7<§eplayer§7>"),
     NO_PERM("§cYou're not allowed to use this command.");
 
     @Getter

--- a/src/main/java/fr/nocsy/mcpets/data/config/PetConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/PetConfig.java
@@ -1,6 +1,7 @@
 package fr.nocsy.mcpets.data.config;
 
 import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.Items;
 import fr.nocsy.mcpets.data.Pet;
 import io.lumine.mythic.api.skills.Skill;
 import lombok.Getter;
@@ -101,6 +102,7 @@ public class PetConfig extends AbstractConfig {
         List<String> description = getConfig().getStringList("Icon.Description");
 
         List<String> signals = getConfig().getStringList("Signals.Values");
+        boolean enableSignalStickFromMenu = getConfig().getBoolean("Signals.Item.GetFromMenu");
         String signalStick_Name = getConfig().getString("Signals.Item.Name");
         String signalStick_Mat = getConfig().getString("Signals.Item.Material");
         int signalStick_Data = getConfig().getInt("Signals.Item.CustomModelData");
@@ -136,6 +138,7 @@ public class PetConfig extends AbstractConfig {
         pet.setComingBackRange(comingbackRange);
         pet.setMountType(mountType);
         pet.setSignals(signals);
+        pet.setEnableSignalStickFromMenu(enableSignalStickFromMenu);
 
         if (despawnSkillName != null) {
             new BukkitRunnable() {
@@ -151,7 +154,7 @@ public class PetConfig extends AbstractConfig {
         }
 
         pet.setIcon(pet.buildItem(pet.getIcon(), pet.toString(), iconName, description, materialType, customModelData, textureBase64));
-        pet.setSignalStick(pet.buildItem(pet.getSignalStick(), Pet.SIGNAL_STICK_TAG, signalStick_Name, signalStick_Description, signalStick_Mat, signalStick_Data, signalStick_64));
+        pet.setSignalStick(pet.buildItem(pet.getSignalStick(), Items.buildSignalStickTag(pet), signalStick_Name, signalStick_Description, signalStick_Mat, signalStick_Data, signalStick_64));
 
         this.pet = pet;
     }

--- a/src/main/java/fr/nocsy/mcpets/data/config/PetConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/PetConfig.java
@@ -3,14 +3,17 @@ package fr.nocsy.mcpets.data.config;
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.data.Items;
 import fr.nocsy.mcpets.data.Pet;
+import fr.nocsy.mcpets.data.PetSkin;
 import io.lumine.mythic.api.skills.Skill;
 import lombok.Getter;
+import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.File;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class PetConfig extends AbstractConfig {
 
@@ -162,6 +165,24 @@ public class PetConfig extends AbstractConfig {
 
         pet.setIcon(pet.buildItem(pet.getIcon(), pet.toString(), iconName, description, materialType, customModelData, textureBase64));
         pet.setSignalStick(pet.buildItem(pet.getSignalStick(), Items.buildSignalStickTag(pet), signalStick_Name, signalStick_Description, signalStick_Mat, signalStick_Data, signalStick_64));
+
+        PetSkin.clearList();
+        for(String key : getConfig().getKeys(true).stream()
+                                                        .filter(key ->
+                                                                   key.contains("Skins") &&
+                                                                   key.replace(".", ";").split(";").length == 2)
+                                                        .collect(Collectors.toList()))
+        {
+            String modelSkinId = getConfig().getString(key + ".Model");
+            String skinPerm = getConfig().getString(key + ".Permission");
+
+            PetSkin.load(pet, modelSkinId, skinPerm, pet.buildItem(null, "",
+                                                                        getConfig().getString(key + ".Icon.DisplayName"),
+                                                                        getConfig().getStringList(key + ".Icon.Lore"),
+                                                                        getConfig().getString(key + ".Icon.Material"),
+                                                                        getConfig().getInt(key + ".Icon.CustomModelData"),
+                                                                        getConfig().getString(key + ".Icon.TextureBase64")));
+        }
 
         this.pet = pet;
     }

--- a/src/main/java/fr/nocsy/mcpets/data/config/PetConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/PetConfig.java
@@ -94,6 +94,9 @@ public class PetConfig extends AbstractConfig {
         String despawnSkillName = getConfig().getString("DespawnSkill");
         boolean autoRide = getConfig().getBoolean("AutoRide");
         String mountType = getConfig().getString("MountType");
+        int inventorySize = Math.min(getConfig().getInt("InventorySize"), 54);
+        while(inventorySize < 54 && inventorySize % 9 != 0)
+            inventorySize++;
 
         String iconName = getConfig().getString("Icon.Name");
         String materialType = getConfig().getString("Icon.Material");
@@ -137,6 +140,7 @@ public class PetConfig extends AbstractConfig {
         pet.setSpawnRange(spawnRange);
         pet.setComingBackRange(comingbackRange);
         pet.setMountType(mountType);
+        pet.setInventorySize(inventorySize);
         pet.setSignals(signals);
         pet.setEnableSignalStickFromMenu(enableSignalStickFromMenu);
 

--- a/src/main/java/fr/nocsy/mcpets/data/config/PetConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/PetConfig.java
@@ -105,7 +105,10 @@ public class PetConfig extends AbstractConfig {
         List<String> description = getConfig().getStringList("Icon.Description");
 
         List<String> signals = getConfig().getStringList("Signals.Values");
-        boolean enableSignalStickFromMenu = getConfig().getBoolean("Signals.Item.GetFromMenu");
+        boolean enableSignalStickFromMenu = true;
+        if(getConfig().get("Signals.Item.GetFromMenu") != null)
+            enableSignalStickFromMenu = getConfig().getBoolean("Signals.Item.GetFromMenu");
+
         String signalStick_Name = getConfig().getString("Signals.Item.Name");
         String signalStick_Mat = getConfig().getString("Signals.Item.Material");
         int signalStick_Data = getConfig().getInt("Signals.Item.CustomModelData");

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/CategoriesMenu.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/CategoriesMenu.java
@@ -1,0 +1,63 @@
+package fr.nocsy.mcpets.data.inventories;
+
+import fr.nocsy.mcpets.data.Category;
+import fr.nocsy.mcpets.data.config.Language;
+import lombok.Getter;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+public class CategoriesMenu {
+
+    @Getter
+    private static final String title = Language.CATEGORY_MENU_TITLE.getMessage();
+
+    private static Inventory inventory;
+
+    public static void init()
+    {
+        int invSize = Category.getCategories().size();
+        while(invSize == 0 || invSize%9 != 0)
+            invSize++;
+
+        inventory = Bukkit.createInventory(null, invSize, title);
+
+        Category.getCategories()
+                .forEach(category -> {
+                    inventory.addItem(category.getIcon());
+                });
+    }
+
+    public static void open(Player p)
+    {
+        p.openInventory(inventory);
+    }
+
+    public static Category findCategory(ItemStack icon)
+    {
+        if(icon == null)
+            return null;
+
+        if(icon.hasItemMeta() &&
+            icon.getItemMeta().hasLocalizedName() &&
+            icon.getItemMeta().getLocalizedName().contains("MCPetsCategory"))
+        {
+            String[] data = icon.getItemMeta().getLocalizedName().split(";");
+            if(data.length == 2)
+            {
+                String catId = data[1];
+                return Category.getFromId(catId);
+            }
+        }
+        return null;
+    }
+
+    public static void openSubCategory(Player p, ItemStack icon)
+    {
+        Category category = findCategory(icon);
+        if(category != null)
+            category.openInventory(p, 0);
+    }
+
+}

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/CategoriesMenu.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/CategoriesMenu.java
@@ -1,6 +1,7 @@
 package fr.nocsy.mcpets.data.inventories;
 
 import fr.nocsy.mcpets.data.Category;
+import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.config.Language;
 import lombok.Getter;
 import org.bukkit.Bukkit;
@@ -13,24 +14,24 @@ public class CategoriesMenu {
     @Getter
     private static final String title = Language.CATEGORY_MENU_TITLE.getMessage();
 
-    private static Inventory inventory;
-
-    public static void init()
+    public static void open(Player p)
     {
         int invSize = Category.getCategories().size();
         while(invSize == 0 || invSize%9 != 0)
             invSize++;
 
-        inventory = Bukkit.createInventory(null, invSize, title);
+        Inventory inventory = Bukkit.createInventory(null, invSize, title);
 
         Category.getCategories()
                 .forEach(category -> {
-                    inventory.addItem(category.getIcon());
+                    for(Pet pet : category.getPets())
+                        if (pet.has(p))
+                        {
+                            inventory.addItem(category.getIcon());
+                            break;
+                        }
                 });
-    }
 
-    public static void open(Player p)
-    {
         p.openInventory(inventory);
     }
 

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetInteractionMenu.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetInteractionMenu.java
@@ -20,7 +20,7 @@ public class PetInteractionMenu {
     private final Inventory inventory;
 
     public PetInteractionMenu(Pet pet) {
-        inventory = Bukkit.createInventory(null, InventoryType.HOPPER, title);
+        inventory = Bukkit.createInventory(null, 9, title);
 
         if (GlobalConfig.getInstance().isActivateBackMenuIcon())
             inventory.setItem(0, Items.PETMENU.getItem());
@@ -28,21 +28,26 @@ public class PetInteractionMenu {
             inventory.setItem(0, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
 
         if (GlobalConfig.getInstance().isNameable())
-            inventory.setItem(1, Items.RENAME.getItem());
+            inventory.setItem(3, Items.RENAME.getItem());
         else
-            inventory.setItem(1, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
-
-        inventory.setItem(2, Items.petInfo(pet));
-
-        if (GlobalConfig.getInstance().isMountable() && pet.isMountable()) {
-            inventory.setItem(3, Items.MOUNT.getItem());
-        } else
             inventory.setItem(3, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
 
-        if (!pet.getSignals().isEmpty()) {
-            inventory.setItem(4, pet.getSignalStick());
+        inventory.setItem(4, Items.petInfo(pet));
+
+        if (GlobalConfig.getInstance().isMountable() && pet.isMountable()) {
+            inventory.setItem(5, Items.MOUNT.getItem());
         } else
-            inventory.setItem(4, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
+            inventory.setItem(5, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
+
+        if (!pet.getSignals().isEmpty()) {
+            inventory.setItem(6, pet.getSignalStick());
+        } else
+            inventory.setItem(6, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
+
+        if (pet.getInventorySize() > 0) {
+            inventory.setItem(7, Items.INVENTORY.getItem());
+        } else
+            inventory.setItem(7, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
     }
 
     public void open(Player p) {

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetInteractionMenu.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetInteractionMenu.java
@@ -24,30 +24,15 @@ public class PetInteractionMenu {
 
         if (GlobalConfig.getInstance().isActivateBackMenuIcon())
             inventory.setItem(0, Items.PETMENU.getItem());
-        else
-            inventory.setItem(0, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
-
         if (GlobalConfig.getInstance().isNameable())
             inventory.setItem(3, Items.RENAME.getItem());
-        else
-            inventory.setItem(3, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
-
-        inventory.setItem(4, Items.petInfo(pet));
-
-        if (GlobalConfig.getInstance().isMountable() && pet.isMountable()) {
+        if (GlobalConfig.getInstance().isMountable() && pet.isMountable())
             inventory.setItem(5, Items.MOUNT.getItem());
-        } else
-            inventory.setItem(5, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
-
-        if (!pet.getSignals().isEmpty()) {
+        if (!pet.getSignals().isEmpty() && pet.isEnableSignalStickFromMenu())
             inventory.setItem(6, pet.getSignalStick());
-        } else
-            inventory.setItem(6, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
-
-        if (pet.getInventorySize() > 0) {
+        if (pet.getInventorySize() > 0)
             inventory.setItem(7, Items.INVENTORY.getItem());
-        } else
-            inventory.setItem(7, Items.deco(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
+        inventory.setItem(4, Items.petInfo(pet));
     }
 
     public void open(Player p) {

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetInteractionMenu.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetInteractionMenu.java
@@ -24,6 +24,8 @@ public class PetInteractionMenu {
 
         if (GlobalConfig.getInstance().isActivateBackMenuIcon())
             inventory.setItem(0, Items.PETMENU.getItem());
+        if (pet.hasSkins())
+            inventory.setItem(2, Items.SKINS.getItem());
         if (GlobalConfig.getInstance().isNameable())
             inventory.setItem(3, Items.RENAME.getItem());
         if (GlobalConfig.getInstance().isMountable() && pet.isMountable())

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetInventory.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetInventory.java
@@ -1,0 +1,145 @@
+package fr.nocsy.mcpets.data.inventories;
+
+import fr.nocsy.mcpets.data.Pet;
+import fr.nocsy.mcpets.data.config.FormatArg;
+import fr.nocsy.mcpets.data.config.Language;
+import fr.nocsy.mcpets.utils.BukkitSerialization;
+import lombok.Getter;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.UUID;
+
+public class PetInventory {
+
+    @Getter
+    private static HashMap<UUID, HashMap<String, PetInventory>> petInventories = new HashMap<>();
+
+    private Inventory inventory;
+
+    private final Pet pet;
+
+    /**
+     * Constructor
+     * Inventory can either be forced or created automatically using null
+     * @param pet
+     * @param premadeInventory
+     */
+    private PetInventory(Pet pet, @Nullable Inventory premadeInventory)
+    {
+        if(pet == null)
+            throw new NullPointerException("Pet can not be null.");
+        this.pet = pet;
+        String title = Language.PET_INVENTORY_TITLE.getMessageFormatted(new FormatArg("pet", pet.getIcon().getItemMeta().getDisplayName()));
+        if(premadeInventory == null)
+            this.inventory = Bukkit.createInventory(null, pet.getInventorySize(), title);
+        else
+            this.inventory = premadeInventory;
+
+        HashMap<String, PetInventory> builtIn = petInventories.get(pet.getOwner());
+        if(builtIn == null)
+        {
+            HashMap<String, PetInventory> map = new HashMap<>();
+            map.put(pet.getId(), this);
+            petInventories.put(pet.getOwner(), map);
+        }
+        else
+        {
+            builtIn.put(pet.getId(), this);
+            petInventories.put(pet.getOwner(), builtIn);
+        }
+    }
+
+    /**
+     * Get the corresponding pet inventory of the said pet
+     * null if the pet has no owner
+     * @param pet
+     * @return
+     */
+    public static PetInventory get(Pet pet)
+    {
+        if(pet.getOwner() == null)
+            return null;
+        HashMap<String, PetInventory> registeredMap = petInventories.get(pet.getOwner());
+        if(registeredMap != null)
+        {
+            PetInventory instance = registeredMap.get(pet.getId());
+            return instance;
+        }
+        return new PetInventory(pet, null);
+    }
+
+    /**
+     * Unserialize the pet inventory from the DB
+     * associate it to the said owner
+     * @param serialized
+     * @param owner
+     * @return
+     */
+    public static PetInventory unserialize(String serialized, @NotNull UUID owner) {
+        String[] data = serialized.split(";");
+        if(data.length != 2)
+            throw new IllegalArgumentException("Serialized doesn't match the data format : " + serialized);
+        String petId = data[0];
+
+        Pet pet = Pet.getFromId(petId);
+        if(pet == null)
+            return null;
+
+        pet.setOwner(owner);
+        String serializedInventory = data[1];
+        try
+        {
+            Inventory inventory = unserializeInventory(serializedInventory);
+            return new PetInventory(pet, inventory);
+        }
+        catch(IOException ex)
+        {
+            return null;
+        }
+
+    }
+
+    /**
+     * Serialize the pet inventory formatted for the DB
+     * @return
+     */
+    public String serialize()
+    {
+        return serializeInventory();
+    }
+
+    /**
+     * Open the inventory to the said player
+     * @param p
+     */
+    public void open(Player p)
+    {
+        p.openInventory(this.inventory);
+    }
+
+    /**
+     * Serialize the inventory only
+     * @return
+     */
+    private String serializeInventory()
+    {
+        return BukkitSerialization.toBase64(this.inventory);
+    }
+
+    /**
+     * Unserialize the inventory only
+     * @param serialized
+     * @return
+     * @throws IOException
+     */
+    private static Inventory unserializeInventory(String serialized) throws IOException {
+        return BukkitSerialization.fromBase64(serialized);
+    }
+
+}

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetInventory.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetInventory.java
@@ -26,7 +26,6 @@ public class PetInventory {
     @Getter
     private static HashMap<UUID, HashMap<String, PetInventory>> petInventories = new HashMap<>();
 
-    @Setter
     private Inventory inventory;
 
     private final Pet pet;
@@ -89,6 +88,13 @@ public class PetInventory {
             return registeredMap.get(pet.getId());
         }
         return new PetInventory(pet, null);
+    }
+
+    public void setInventory(Inventory inventory)
+    {
+        this.inventory = inventory;
+        PlayerData pd = PlayerData.get(pet.getOwner());
+        pd.setPetInventory(this);
     }
 
     /**
@@ -160,11 +166,14 @@ public class PetInventory {
     public void close(Player p)
     {
         p.setMetadata("MCPets;petInventory", new FixedMetadataValue(MCPets.getInstance(), null));
-
-        if(!GlobalConfig.getInstance().isDatabaseSupport())
-            PlayerDataNoDatabase.get(p.getUniqueId()).save();
-        else
-            PlayerData.saveDB();
+        new Thread(new Runnable() {
+            public void run() {
+                if(!GlobalConfig.getInstance().isDatabaseSupport())
+                    PlayerDataNoDatabase.get(p.getUniqueId()).save();
+                else
+                    PlayerData.saveDB();
+            }
+        }).start();
     }
 
     /**
@@ -210,6 +219,15 @@ public class PetInventory {
      */
     private static Inventory unserializeInventory(String serialized) throws IOException {
         return BukkitSerialization.fromBase64(serialized);
+    }
+
+    /**
+     * Get the pet ID
+     * @return
+     */
+    public String getPetId()
+    {
+        return pet.getId();
     }
 
 }

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetMenu.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetMenu.java
@@ -49,7 +49,7 @@ public class PetMenu {
             Pet pet = availablePets.get(i);
 
             if (i % 53 == 0 && i > page * 53) {
-                inventory.setItem(invSize - 1, Items.page(page));
+                inventory.setItem(invSize - 1, Items.page(page, p));
                 break;
             }
             inventory.addItem(pet.getIcon());
@@ -57,7 +57,7 @@ public class PetMenu {
         }
 
         if (addPager) {
-            inventory.setItem(invSize - 1, Items.page(page));
+            inventory.setItem(invSize - 1, Items.page(page, p));
         }
 
     }

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetMenu.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetMenu.java
@@ -1,5 +1,6 @@
 package fr.nocsy.mcpets.data.inventories;
 
+import fr.nocsy.mcpets.data.Category;
 import fr.nocsy.mcpets.data.Items;
 import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.config.GlobalConfig;
@@ -62,6 +63,11 @@ public class PetMenu {
     }
 
     public void open(Player p) {
+        if(Category.getCategories().size() > 0)
+        {
+            CategoriesMenu.open(p);
+            return;
+        }
         p.openInventory(inventory);
     }
 

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PlayerData.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PlayerData.java
@@ -80,6 +80,15 @@ public class PlayerData {
         reload();
     }
 
+    /**
+     * Register the Pet inventory for future save
+     * @param petInventory
+     */
+    public void setPetInventory(PetInventory petInventory)
+    {
+        mapOfRegisteredInventories.put(petInventory.getPetId(), petInventory.serialize());
+    }
+
     public void save() {
         if (GlobalConfig.getInstance().isDatabaseSupport())
             saveDB();

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PlayerData.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PlayerData.java
@@ -1,20 +1,27 @@
 package fr.nocsy.mcpets.data.inventories;
 
+import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.config.GlobalConfig;
 import fr.nocsy.mcpets.data.sql.Databases;
 import lombok.Getter;
 import lombok.Setter;
+import org.bukkit.inventory.Inventory;
 
 import java.util.HashMap;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class PlayerData {
 
     @Getter
     private static final HashMap<UUID, PlayerData> registeredData = new HashMap<>();
+
     @Getter
     @Setter
     private HashMap<String, String> mapOfRegisteredNames = new HashMap<>();
+    @Getter
+    @Setter
+    private HashMap<String, String> mapOfRegisteredInventories = new HashMap<>();
 
     @Setter
     @Getter
@@ -39,6 +46,7 @@ public class PlayerData {
                 data.setUuid(owner);
                 PlayerDataNoDatabase pdn = PlayerDataNoDatabase.get(owner);
                 data.setMapOfRegisteredNames(pdn.mapOfRegisteredNames);
+                data.setMapOfRegisteredInventories(pdn.mapOfRegisteredInventories);
                 registeredData.put(owner, data);
 
                 return data;
@@ -78,6 +86,16 @@ public class PlayerData {
         else {
             PlayerDataNoDatabase pdn = PlayerDataNoDatabase.get(uuid);
             pdn.setMapOfRegisteredNames(mapOfRegisteredNames);
+
+            mapOfRegisteredInventories.clear();
+            HashMap<String, PetInventory> inventories = PetInventory.getPetInventories().get(this.getUuid());
+
+            for(String petId : inventories.keySet())
+            {
+                mapOfRegisteredInventories.put(petId, inventories.get(petId).serialize());
+            }
+
+            pdn.setMapOfRegisteredInventories(mapOfRegisteredInventories);
             pdn.save();
         }
     }

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PlayerDataNoDatabase.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PlayerDataNoDatabase.java
@@ -51,29 +51,31 @@ public class PlayerDataNoDatabase extends AbstractConfig {
     @Override
     public void save() {
 
-        ArrayList<String> serializedMap = new ArrayList<>();
+        ArrayList<String> serializedNamesMap = new ArrayList<>();
 
         for (String id : mapOfRegisteredNames.keySet()) {
             String name = mapOfRegisteredNames.get(id);
             String seria = id + ";" + name;
-            serializedMap.add(seria);
+            serializedNamesMap.add(seria);
         }
 
-        getConfig().set("Names", serializedMap);
+        getConfig().set("Names", serializedNamesMap);
 
-        serializedMap.clear();
+        ArrayList<String> serializedInventoriesMap = new ArrayList<>();
         mapOfRegisteredInventories.clear();
-        HashMap<String, PetInventory> inventories = PetInventory.getPetInventories().get(this.getUuid());
-
-        for(String petId : inventories.keySet())
+        if(PetInventory.getPetInventories().containsKey(uuid))
         {
-            mapOfRegisteredInventories.put(petId, inventories.get(petId).serialize());
-            String seriaInv = mapOfRegisteredInventories.get(petId);
-            String seria = petId + ";" + seriaInv;
-            serializedMap.add(seria);
+            HashMap<String, PetInventory> inventories = PetInventory.getPetInventories().get(uuid);
+            for(String petId : inventories.keySet())
+            {
+                mapOfRegisteredInventories.put(petId, inventories.get(petId).serialize());
+                String seriaInv = mapOfRegisteredInventories.get(petId);
+                String seria = petId + ";" + seriaInv;
+                serializedInventoriesMap.add(seria);
+            }
         }
 
-        getConfig().set("Inventories", serializedMap);
+        getConfig().set("Inventories", serializedInventoriesMap);
 
         super.save();
     }
@@ -82,7 +84,6 @@ public class PlayerDataNoDatabase extends AbstractConfig {
     public void reload() {
 
         mapOfRegisteredNames.clear();
-
         for (String seria : getConfig().getStringList("Names")) {
             String[] table = seria.split(";");
             String id = table[0];
@@ -98,7 +99,7 @@ public class PlayerDataNoDatabase extends AbstractConfig {
             String seriaInventory = table[1];
 
             mapOfRegisteredInventories.put(id, seriaInventory);
-            PetInventory.unserialize(seriaInventory, this.getUuid());
+            PetInventory.unserialize(seria, uuid);
         }
 
     }

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PlayerDataNoDatabase.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PlayerDataNoDatabase.java
@@ -17,6 +17,9 @@ public class PlayerDataNoDatabase extends AbstractConfig {
     @Getter
     @Setter
     public HashMap<String, String> mapOfRegisteredNames = new HashMap<>();
+    @Getter
+    @Setter
+    public HashMap<String, String> mapOfRegisteredInventories = new HashMap<>();
 
     private PlayerDataNoDatabase(UUID uuid) {
         this.uuid = uuid;
@@ -39,6 +42,8 @@ public class PlayerDataNoDatabase extends AbstractConfig {
 
         if (getConfig().get("Names") == null)
             getConfig().set("Names", new ArrayList<String>());
+        if (getConfig().get("Inventories") == null)
+            getConfig().set("Inventories", new ArrayList<String>());
 
         reload();
     }
@@ -56,6 +61,20 @@ public class PlayerDataNoDatabase extends AbstractConfig {
 
         getConfig().set("Names", serializedMap);
 
+        serializedMap.clear();
+        mapOfRegisteredInventories.clear();
+        HashMap<String, PetInventory> inventories = PetInventory.getPetInventories().get(this.getUuid());
+
+        for(String petId : inventories.keySet())
+        {
+            mapOfRegisteredInventories.put(petId, inventories.get(petId).serialize());
+            String seriaInv = mapOfRegisteredInventories.get(petId);
+            String seria = petId + ";" + seriaInv;
+            serializedMap.add(seria);
+        }
+
+        getConfig().set("Inventories", serializedMap);
+
         super.save();
     }
 
@@ -70,6 +89,16 @@ public class PlayerDataNoDatabase extends AbstractConfig {
             String name = table[1];
 
             mapOfRegisteredNames.put(id, name);
+        }
+
+        mapOfRegisteredInventories.clear();
+        for (String seria : getConfig().getStringList("Inventories")) {
+            String[] table = seria.split(";");
+            String id = table[0];
+            String seriaInventory = table[1];
+
+            mapOfRegisteredInventories.put(id, seriaInventory);
+            PetInventory.unserialize(seriaInventory, this.getUuid());
         }
 
     }

--- a/src/main/java/fr/nocsy/mcpets/data/sql/Databases.java
+++ b/src/main/java/fr/nocsy/mcpets/data/sql/Databases.java
@@ -19,6 +19,8 @@ public class Databases {
     @Setter
     public static MySQLDB mySQL;
 
+    private static String table = "mcpets_player_data";
+
     public static boolean init() {
         if(GlobalConfig.getInstance().isDisableMySQL())
         {
@@ -44,14 +46,14 @@ public class Databases {
     public static void createSQLTables() {
         if (!GlobalConfig.getInstance().isDatabaseSupport())
             return;
-        getMySQL().query("CREATE TABLE IF NOT EXISTS player_data (id INT NOT NULL AUTO_INCREMENT, uuid TEXT, names TEXT, primary key (id));");
+        getMySQL().query("CREATE TABLE IF NOT EXISTS " + table + " (id INT NOT NULL AUTO_INCREMENT, uuid TEXT, names TEXT, inventories TEXT, data TEXT, primary key (id));");
     }
 
     public static boolean loadData() {
         if (!GlobalConfig.getInstance().isDatabaseSupport())
             return false;
 
-        ResultSet playerData = getMySQL().query("SELECT * FROM player_data;");
+        ResultSet playerData = getMySQL().query("SELECT * FROM " + table + ";");
         if (playerData == null)
             return true;
         try {
@@ -70,7 +72,6 @@ public class Databases {
                 }
 
                 PlayerData.getRegisteredData().put(uuid, pd);
-
             }
         } catch (SQLException e1) {
             return false;
@@ -83,16 +84,17 @@ public class Databases {
         if (!GlobalConfig.getInstance().isDatabaseSupport())
             return;
 
-        getMySQL().query("TRUNCATE player_data");
+        getMySQL().query("TRUNCATE " + table);
 
         for (PlayerData pd : PlayerData.getRegisteredData().values()) {
             UUID uuid = pd.getUuid();
 
             String names = buildStringSerialized(pd.getMapOfRegisteredNames());
-            getMySQL().query("INSERT INTO player_data (uuid, names) VALUES ('" + uuid.toString() + "', '" + names + "')");
-
             String inventories = buildStringSerialized(pd.getMapOfRegisteredInventories());
-            getMySQL().query("INSERT INTO player_data (uuid, inventories) VALUES ('" + uuid.toString() + "', '" + inventories + "')");
+            getMySQL().query("INSERT INTO " + table + " (uuid, names, inventories, data) VALUES ('" + uuid.toString()
+                                                                                                    + "', '" + names
+                                                                                                    + "', '" + inventories
+                                                                                                    + "', '" + null + "')");
         }
     }
 

--- a/src/main/java/fr/nocsy/mcpets/data/sql/Databases.java
+++ b/src/main/java/fr/nocsy/mcpets/data/sql/Databases.java
@@ -66,7 +66,7 @@ public class Databases {
                 for(String petId : pd.getMapOfRegisteredInventories().keySet())
                 {
                     String seriaInv = pd.getMapOfRegisteredInventories().get(petId);
-                    PetInventory.unserialize(seriaInv, pd.getUuid());
+                    PetInventory.unserialize(petId + ";" + seriaInv, pd.getUuid());
                 }
 
                 PlayerData.getRegisteredData().put(uuid, pd);

--- a/src/main/java/fr/nocsy/mcpets/data/sql/Databases.java
+++ b/src/main/java/fr/nocsy/mcpets/data/sql/Databases.java
@@ -18,6 +18,11 @@ public class Databases {
     public static MySQLDB mySQL;
 
     public static boolean init() {
+        if(GlobalConfig.getInstance().isDisableMySQL())
+        {
+            MCPets.getInstance().getLogger().info("MySQL is disabled. Flat support will be used.");
+            return false;
+        }
         Databases.setMySQL(new MySQLDB(GlobalConfig.getInstance().getMySQL_USER(),
                 GlobalConfig.getInstance().getMySQL_PASSWORD(),
                 GlobalConfig.getInstance().getMySQL_HOST(),

--- a/src/main/java/fr/nocsy/mcpets/events/PetSpawnEvent.java
+++ b/src/main/java/fr/nocsy/mcpets/events/PetSpawnEvent.java
@@ -2,6 +2,7 @@ package fr.nocsy.mcpets.events;
 
 import fr.nocsy.mcpets.data.Pet;
 import lombok.Getter;
+import org.bukkit.Location;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -12,13 +13,21 @@ public class PetSpawnEvent extends Event implements Cancellable {
     private boolean isCancelled = false;
     @Getter
     private final Pet pet;
+    @Getter
+    private Location where;
 
-    public PetSpawnEvent(Pet pet) {
+    public PetSpawnEvent(Pet pet, Location where) {
         this.pet = pet;
+        this.where = where;
     }
 
     public static HandlerList getHandlerList() {
         return HANDLERS;
+    }
+
+    public void setWhere(Location loc)
+    {
+        where = loc;
     }
 
     @Override

--- a/src/main/java/fr/nocsy/mcpets/listeners/CategoriesMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/CategoriesMenuListener.java
@@ -1,0 +1,29 @@
+package fr.nocsy.mcpets.listeners;
+
+import fr.nocsy.mcpets.data.Category;
+import fr.nocsy.mcpets.data.config.Language;
+import fr.nocsy.mcpets.data.inventories.CategoriesMenu;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+public class CategoriesMenuListener implements Listener {
+
+    @EventHandler
+    public void invClick(InventoryClickEvent e)
+    {
+        if(e.getView().getTitle().equalsIgnoreCase(Language.CATEGORY_MENU_TITLE.getMessage()))
+        {
+            ItemStack icon = e.getCurrentItem();
+            if(icon != null)
+            {
+                CategoriesMenu.openSubCategory((Player) e.getWhoClicked(), icon);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/fr/nocsy/mcpets/listeners/CategoriesMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/CategoriesMenuListener.java
@@ -22,6 +22,7 @@ public class CategoriesMenuListener implements Listener {
             {
                 CategoriesMenu.openSubCategory((Player) e.getWhoClicked(), icon);
             }
+            e.setCancelled(true);
         }
 
     }

--- a/src/main/java/fr/nocsy/mcpets/listeners/CategoryMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/CategoryMenuListener.java
@@ -27,12 +27,14 @@ public class CategoryMenuListener implements Listener {
                 if (it.hasItemMeta() && it.getItemMeta().hasLocalizedName() && it.getItemMeta().getLocalizedName().contains("MCPetsPage;")) {
 
                     int currentPage = category.getCurrentPage(e.getClickedInventory());
-                    p.closeInventory();
+                    boolean opened = true;
                     if (e.getClick() == ClickType.LEFT) {
-                        category.openInventory(p, Math.max(currentPage - 1, 0));
+                        opened = category.openInventory(p, currentPage - 1);
                     } else {
-                        category.openInventory(p, Math.max(currentPage + 1, 0));
+                        opened = category.openInventory(p, currentPage + 1);
                     }
+                    if(opened)
+                        p.closeInventory();
                     return;
                 }
 

--- a/src/main/java/fr/nocsy/mcpets/listeners/CategoryMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/CategoryMenuListener.java
@@ -2,7 +2,6 @@ package fr.nocsy.mcpets.listeners;
 
 import fr.nocsy.mcpets.data.Category;
 import fr.nocsy.mcpets.data.Pet;
-import fr.nocsy.mcpets.data.inventories.PetMenu;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -10,24 +9,29 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
-public class PetMenuListener implements Listener {
+public class CategoryMenuListener implements Listener {
 
     @EventHandler
     public void click(InventoryClickEvent e) {
-        if (e.getView().getTitle().equals(PetMenu.getTitle()) && Category.getCategories().size() == 0) {
+
+        if(Category.getCategories().size() == 0)
+            return;
+
+        Category category = Category.getFromInventory(e.getClickedInventory());
+
+        if (category != null) {
             e.setCancelled(true);
             Player p = (Player) e.getWhoClicked();
             ItemStack it = e.getCurrentItem();
             if (it != null) {
-                if (it.hasItemMeta() && it.getItemMeta().hasLocalizedName() && it.getItemMeta().getLocalizedName().contains("AlmPetPage;")) {
-                    int page = Integer.parseInt(it.getItemMeta().getLocalizedName().split(";")[1]);
+                if (it.hasItemMeta() && it.getItemMeta().hasLocalizedName() && it.getItemMeta().getLocalizedName().contains("MCPetsPage;")) {
+
+                    int currentPage = category.getCurrentPage(e.getClickedInventory());
                     p.closeInventory();
                     if (e.getClick() == ClickType.LEFT) {
-                        PetMenu menu = new PetMenu(p, Math.max(page - 1, 0), true);
-                        menu.open(p);
+                        category.openInventory(p, Math.max(currentPage - 1, 0));
                     } else {
-                        PetMenu menu = new PetMenu(p, page + 1, true);
-                        menu.open(p);
+                        category.openInventory(p, Math.max(currentPage + 1, 0));
                     }
                     return;
                 }
@@ -42,5 +46,4 @@ public class PetMenuListener implements Listener {
 
         }
     }
-
 }

--- a/src/main/java/fr/nocsy/mcpets/listeners/EventListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/EventListener.java
@@ -15,6 +15,9 @@ public class EventListener implements Listener {
         listeners.add(new PetMenuListener());
         listeners.add(new PetInteractionMenuListener());
         listeners.add(new PetListener());
+        listeners.add(new CategoriesMenuListener());
+        listeners.add(new CategoryMenuListener());
+        listeners.add(new PetInventoryListener());
         listeners.add(new SignalStickListener());
 
         listeners.add(new MythicListener());

--- a/src/main/java/fr/nocsy/mcpets/listeners/EventListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/EventListener.java
@@ -19,6 +19,7 @@ public class EventListener implements Listener {
         listeners.add(new CategoryMenuListener());
         listeners.add(new PetInventoryListener());
         listeners.add(new SignalStickListener());
+        listeners.add(new PetSkinsMenuListener());
 
         listeners.add(new MythicListener());
 

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetInteractionMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetInteractionMenuListener.java
@@ -8,6 +8,7 @@ import fr.nocsy.mcpets.data.config.FormatArg;
 import fr.nocsy.mcpets.data.config.GlobalConfig;
 import fr.nocsy.mcpets.data.config.Language;
 import fr.nocsy.mcpets.data.inventories.PetInteractionMenu;
+import fr.nocsy.mcpets.data.inventories.PetInventory;
 import fr.nocsy.mcpets.data.inventories.PetMenu;
 import fr.nocsy.mcpets.utils.Utils;
 import lombok.Getter;
@@ -39,6 +40,15 @@ public class PetInteractionMenuListener implements Listener {
             Language.ALREADY_INSIDE_VEHICULE.sendMessage(p);
         } else if (!pet.setMount(p)) {
             Language.NOT_MOUNTABLE.sendMessage(p);
+        }
+    }
+
+    public static void inventory(Player p, Pet pet)
+    {
+        PetInventory inventory = PetInventory.get(pet);
+        if(inventory != null)
+        {
+            inventory.open(p);
         }
     }
 
@@ -82,12 +92,14 @@ public class PetInteractionMenuListener implements Listener {
                     return;
                 }
 
-                if (e.getSlot() == 2) {
+                if (e.getSlot() == 4) {
                     revoke(p, pet);
                 } else if (it.isSimilar(Items.MOUNT.getItem())) {
                     mount(p, pet);
                 } else if (it.isSimilar(Items.RENAME.getItem())) {
                     changeName(p);
+                } else if (it.isSimilar(Items.INVENTORY.getItem())) {
+                    inventory(p, pet);
                 } else if (it.isSimilar(pet.getSignalStick())) {
                     pet.giveStickSignals(p);
                 }

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetInteractionMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetInteractionMenuListener.java
@@ -80,7 +80,6 @@ public class PetInteractionMenuListener implements Listener {
                     return;
 
                 Pet pet = Pet.getFromLastInteractedWith(p);
-
                 if (pet == null) {
                     p.closeInventory();
                     return;

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetInteractionMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetInteractionMenuListener.java
@@ -1,9 +1,11 @@
 package fr.nocsy.mcpets.listeners;
 
+import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.PPermission;
 import fr.nocsy.mcpets.data.Items;
 import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.PetDespawnReason;
+import fr.nocsy.mcpets.data.PetSkin;
 import fr.nocsy.mcpets.data.config.FormatArg;
 import fr.nocsy.mcpets.data.config.GlobalConfig;
 import fr.nocsy.mcpets.data.config.Language;
@@ -19,6 +21,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
 import java.util.UUID;
@@ -52,6 +55,16 @@ public class PetInteractionMenuListener implements Listener {
         }
     }
 
+    public static void skins(Player p, Pet pet)
+    {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                PetSkin.openInventory(p, pet);
+            }
+        }.runTaskLater(MCPets.getInstance(), 2L);
+    }
+
     public static void revoke(Player p, Pet pet) {
         pet.despawn(PetDespawnReason.REVOKE);
         Language.REVOKED.sendMessage(p);
@@ -72,12 +85,13 @@ public class PetInteractionMenuListener implements Listener {
             ItemStack it = e.getCurrentItem();
             if (it != null && it.hasItemMeta() && it.getItemMeta().hasDisplayName()) {
 
-                if (it.getItemMeta().hasLocalizedName() && it.getItemMeta().getLocalizedName().equals(Items.PETMENU.getItem().getItemMeta().getLocalizedName())) {
+                if (it.getItemMeta().hasLocalizedName() && it.getItemMeta().getLocalizedName().contains("AlmPetPage;"))
+                    return;
+                if(it.isSimilar(Items.PETMENU.getItem()))
+                {
                     openBackPetMenu(p);
                     return;
                 }
-                if (it.getItemMeta().hasLocalizedName() && it.getItemMeta().getLocalizedName().contains("AlmPetPage;"))
-                    return;
 
                 Pet pet = Pet.getFromLastInteractedWith(p);
                 if (pet == null) {
@@ -101,6 +115,8 @@ public class PetInteractionMenuListener implements Listener {
                     inventory(p, pet);
                 } else if (it.isSimilar(pet.getSignalStick())) {
                     pet.giveStickSignals(p);
+                } else if(it.isSimilar(Items.SKINS.getItem())) {
+                    skins(p, pet);
                 }
                 p.closeInventory();
             }

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetInventoryListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetInventoryListener.java
@@ -1,0 +1,28 @@
+package fr.nocsy.mcpets.listeners;
+
+import fr.nocsy.mcpets.data.config.Language;
+import fr.nocsy.mcpets.data.inventories.PetInventory;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+
+public class PetInventoryListener implements Listener {
+
+    @EventHandler
+    public void inventory(InventoryCloseEvent e)
+    {
+
+        Player p = (Player)e.getPlayer();
+        PetInventory petInventory = PetInventory.fromCurrentView(p);
+
+        if(petInventory != null)
+        {
+            petInventory.setInventory(e.getView().getTopInventory());
+            petInventory.close(p);
+        }
+
+    }
+
+}

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
@@ -2,11 +2,13 @@ package fr.nocsy.mcpets.listeners;
 
 import com.sk89q.worldguard.bukkit.event.entity.SpawnEntityEvent;
 import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.Items;
 import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.PetDespawnReason;
 import fr.nocsy.mcpets.data.config.GlobalConfig;
 import fr.nocsy.mcpets.data.config.Language;
 import fr.nocsy.mcpets.data.inventories.PetInteractionMenu;
+import fr.nocsy.mcpets.events.PetSpawnEvent;
 import io.lumine.mythic.bukkit.events.MythicMobDeathEvent;
 import io.lumine.mythic.bukkit.events.MythicMobDespawnEvent;
 import io.lumine.mythic.bukkit.events.MythicMobSpawnEvent;
@@ -19,6 +21,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.*;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -38,6 +41,13 @@ public class PetListener implements Listener {
 
         if (GlobalConfig.getInstance().isSneakMode() && !p.isSneaking())
             return;
+
+        if(GlobalConfig.getInstance().isDisableInventoryWhileHoldingSignalStick())
+        {
+            ItemStack it = p.getInventory().getItemInMainHand();
+            if(Items.isSignalStick(it))
+                return;
+        }
 
         Entity ent = e.getRightClicked();
 
@@ -204,6 +214,30 @@ public class PetListener implements Listener {
                         Language.REVOKED.sendMessage(owner);
                     }
                 }
+            }
+        }
+    }
+
+    /**
+     * Blacklisted world system
+     * @param e
+     */
+    @EventHandler
+    public void blacklistedWorld(PetSpawnEvent e)
+    {
+        if(e.getPet() == null
+                || e.getPet().getActiveMob() == null
+                || e.getPet().getActiveMob().getLocation() == null
+                || e.getPet().getActiveMob().getLocation().getWorld() == null)
+            return;
+
+        if(GlobalConfig.getInstance().hasBlackListedWorld(e.getPet().getActiveMob().getLocation().getWorld().getName()))
+        {
+            e.setCancelled(true);
+            Player p = Bukkit.getPlayer(e.getPet().getOwner());
+            if(p != null)
+            {
+                Language.BLACKLISTED_WORLD.sendMessage(p);
             }
         }
     }

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
@@ -224,13 +224,7 @@ public class PetListener implements Listener {
     @EventHandler
     public void blacklistedWorld(PetSpawnEvent e)
     {
-        if(e.getPet() == null
-                || e.getPet().getActiveMob() == null
-                || e.getPet().getActiveMob().getLocation() == null
-                || e.getPet().getActiveMob().getLocation().getWorld() == null)
-            return;
-
-        if(GlobalConfig.getInstance().hasBlackListedWorld(e.getPet().getActiveMob().getLocation().getWorld().getName()))
+        if(GlobalConfig.getInstance().hasBlackListedWorld(e.getWhere().getWorld().getName()))
         {
             e.setCancelled(true);
             Player p = Bukkit.getPlayer(e.getPet().getOwner());

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
@@ -22,7 +22,6 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.HashMap;
@@ -56,7 +55,7 @@ public class PetListener implements Listener {
         if (pet != null &&
                 (pet.getOwner().equals(p.getUniqueId()) || p.isOp())) {
             PetInteractionMenu menu = new PetInteractionMenu(pet);
-            p.setMetadata("AlmPetInteracted", new FixedMetadataValue(MCPets.getInstance(), pet));
+            pet.setLastInteractedWith(p);
             menu.open(p);
         }
     }
@@ -81,7 +80,7 @@ public class PetListener implements Listener {
         if (pet != null &&
                 (pet.getOwner().equals(p.getUniqueId()) || p.isOp())) {
             PetInteractionMenu menu = new PetInteractionMenu(pet);
-            p.setMetadata("AlmPetInteracted", new FixedMetadataValue(MCPets.getInstance(), pet));
+            pet.setLastInteractedWith(p);
             menu.open(p);
             e.setCancelled(true);
             e.setDamage(0);

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
@@ -189,7 +189,7 @@ public class PetListener implements Listener {
                     pet.despawn(PetDespawnReason.MYTHICMOBS);
                     Player owner = Bukkit.getPlayer(pet.getOwner());
                     if (owner != null) {
-                        Language.REVOKED.sendMessage(owner);
+                        Language.REVOKED_UNKNOWN.sendMessage(owner);
                     }
                 }
             }

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetSkinsMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetSkinsMenuListener.java
@@ -1,0 +1,64 @@
+package fr.nocsy.mcpets.listeners;
+
+import fr.nocsy.mcpets.data.Pet;
+import fr.nocsy.mcpets.data.PetSkin;
+import fr.nocsy.mcpets.data.config.Language;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class PetSkinsMenuListener implements Listener {
+
+    @EventHandler
+    public void click(InventoryClickEvent e)
+    {
+
+        Player p = (Player)e.getWhoClicked();
+
+        if(PetSkin.hasMetadata(p))
+        {
+            e.setCancelled(true);
+
+            ItemStack it = e.getCurrentItem();
+            if(it != null && it.hasItemMeta())
+            {
+                PetSkin petSkin = PetSkin.fromIcon(it);
+                if(petSkin != null)
+                {
+                    Pet pet = Pet.fromOwner(p.getUniqueId());
+                    if(pet == null)
+                    {
+                        Language.REVOKED_BEFORE_CHANGES.sendMessage(p);
+                        p.closeInventory();
+                        return;
+                    }
+
+                    if(petSkin.apply(pet))
+                        Language.SKIN_APPLIED.sendMessage(p);
+                    else
+                        Language.SKIN_COULD_NOT_APPLY.sendMessage(p);
+
+                    p.closeInventory();
+                }
+            }
+
+        }
+
+    }
+
+    @EventHandler
+    public void close(InventoryCloseEvent e)
+    {
+
+        Player p = (Player) e.getPlayer();
+        if(PetSkin.hasMetadata(p))
+        {
+            PetSkin.removeMetadata(p);
+        }
+
+    }
+
+}

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/MythicListener.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/MythicListener.java
@@ -2,6 +2,7 @@ package fr.nocsy.mcpets.mythicmobs;
 
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.mythicmobs.mechanics.GivePetMechanic;
+import fr.nocsy.mcpets.mythicmobs.mechanics.PetFollowMechanic;
 import fr.nocsy.mcpets.mythicmobs.mechanics.SetPetMechanic;
 import fr.nocsy.mcpets.mythicmobs.targeters.TargeterPetOwner;
 import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
@@ -25,13 +26,21 @@ public class MythicListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onMythicMechanicLoad(MythicMechanicLoadEvent event) {
-        if (event.getMechanicName().equalsIgnoreCase("GivePet")) {
+        if (event.getMechanicName().equalsIgnoreCase("GivePet"))
+        {
             GivePetMechanic mechanic = new GivePetMechanic(event.getConfig());
             event.register(mechanic);
             MCPets.getLog().info("[MCPets] : " + event.getMechanicName() + " Mechanic loaded successfully");
         }
-        else if (event.getMechanicName().equalsIgnoreCase("SetPet")) {
+        else if (event.getMechanicName().equalsIgnoreCase("SetPet"))
+        {
             SetPetMechanic mechanic = new SetPetMechanic(event.getConfig());
+            event.register(mechanic);
+            MCPets.getLog().info("[MCPets] : " + event.getMechanicName() + " Mechanic loaded successfully");
+        }
+        else if (event.getMechanicName().equalsIgnoreCase("PetFollow"))
+        {
+            PetFollowMechanic mechanic = new PetFollowMechanic(event.getConfig());
             event.register(mechanic);
             MCPets.getLog().info("[MCPets] : " + event.getMechanicName() + " Mechanic loaded successfully");
         }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/MythicListener.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/MythicListener.java
@@ -2,6 +2,7 @@ package fr.nocsy.mcpets.mythicmobs;
 
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.mythicmobs.mechanics.GivePetMechanic;
+import fr.nocsy.mcpets.mythicmobs.mechanics.SetPetMechanic;
 import fr.nocsy.mcpets.mythicmobs.targeters.TargeterPetOwner;
 import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 import io.lumine.mythic.bukkit.events.MythicTargeterLoadEvent;
@@ -25,11 +26,14 @@ public class MythicListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onMythicMechanicLoad(MythicMechanicLoadEvent event) {
         if (event.getMechanicName().equalsIgnoreCase("GivePet")) {
-            GivePetMechanic givePetMechanic = new GivePetMechanic(event.getConfig());
-            event.register(givePetMechanic);
-
-            MCPets.getLog().info("[MCPets] : GivePet Mechanic loaded successfully");
-
+            GivePetMechanic mechanic = new GivePetMechanic(event.getConfig());
+            event.register(mechanic);
+            MCPets.getLog().info("[MCPets] : " + event.getMechanicName() + " Mechanic loaded successfully");
+        }
+        else if (event.getMechanicName().equalsIgnoreCase("SetPet")) {
+            SetPetMechanic mechanic = new SetPetMechanic(event.getConfig());
+            event.register(mechanic);
+            MCPets.getLog().info("[MCPets] : " + event.getMechanicName() + " Mechanic loaded successfully");
         }
     }
 

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetFollowMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetFollowMechanic.java
@@ -1,0 +1,34 @@
+package fr.nocsy.mcpets.mythicmobs.mechanics;
+
+import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.Pet;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.config.MythicLineConfig;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+public class PetFollowMechanic implements ITargetedEntitySkill {
+
+    boolean follow = true;
+
+    public PetFollowMechanic(MythicLineConfig config) {
+        this.follow = config.getBoolean(new String[]{"follow"}, this.follow);
+    }
+
+    public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
+        Entity entity = BukkitAdapter.adapt(target);
+
+        Pet pet = Pet.getFromEntity(entity);
+        if(pet != null)
+        {
+            pet.setFollowOwner(follow);
+            return SkillResult.SUCCESS;
+        }
+        return SkillResult.CONDITION_FAILED;
+
+    }
+}

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/SetPetMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/SetPetMechanic.java
@@ -1,0 +1,45 @@
+package fr.nocsy.mcpets.mythicmobs.mechanics;
+
+import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.Pet;
+import fr.nocsy.mcpets.data.PetDespawnReason;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.config.MythicLineConfig;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.core.mobs.ActiveMob;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import java.util.Optional;
+
+public class SetPetMechanic implements ITargetedEntitySkill {
+
+    String petId;
+    boolean mustHavePermission;
+
+    public SetPetMechanic(MythicLineConfig config) {
+        this.petId = config.getString(new String[]{"id"}, this.petId);
+        this.mustHavePermission =  config.getBoolean(new String[]{"mustHavePermission","permCheck"}, this.mustHavePermission);
+    }
+
+    public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
+        Entity player = BukkitAdapter.adapt(target);
+        if (player instanceof Player) {
+
+            Pet pet = Pet.getFromId(petId);
+            if (pet == null)
+                return SkillResult.CONDITION_FAILED;
+
+            Pet currentPet = Pet.fromOwner(player.getUniqueId());
+            if(currentPet != null)
+                currentPet.despawn(PetDespawnReason.REVOKE);
+
+            Optional<ActiveMob> opt = MCPets.getMythicMobs().getMobManager().getActiveMob(data.getCaster().getEntity().getUniqueId());
+            opt.ifPresent(pet::changeActiveMobTo);
+        }
+        return SkillResult.SUCCESS;
+    }
+}

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/SetPetMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/SetPetMechanic.java
@@ -41,7 +41,7 @@ public class SetPetMechanic implements ITargetedEntitySkill {
                     Pet currentPet = Pet.fromOwner(player.getUniqueId());
                     if(currentPet != null)
                     {
-                        currentPet.despawn(PetDespawnReason.REPLACED);
+                        currentPet.despawn(PetDespawnReason.SETPET_REPLACED);
                     }
 
                     Optional<ActiveMob> opt = MCPets.getMythicMobs().getMobManager().getActiveMob(data.getCaster().getEntity().getUniqueId());

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/SetPetMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/SetPetMechanic.java
@@ -12,6 +12,7 @@ import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.core.mobs.ActiveMob;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Optional;
 
@@ -33,12 +34,22 @@ public class SetPetMechanic implements ITargetedEntitySkill {
             if (pet == null)
                 return SkillResult.CONDITION_FAILED;
 
-            Pet currentPet = Pet.fromOwner(player.getUniqueId());
-            if(currentPet != null)
-                currentPet.despawn(PetDespawnReason.REVOKE);
+            new BukkitRunnable() {
+                @Override
+                public void run() {
 
-            Optional<ActiveMob> opt = MCPets.getMythicMobs().getMobManager().getActiveMob(data.getCaster().getEntity().getUniqueId());
-            opt.ifPresent(pet::changeActiveMobTo);
+                    Pet currentPet = Pet.fromOwner(player.getUniqueId());
+                    if(currentPet != null)
+                    {
+                        currentPet.despawn(PetDespawnReason.REPLACED);
+                    }
+
+                    Optional<ActiveMob> opt = MCPets.getMythicMobs().getMobManager().getActiveMob(data.getCaster().getEntity().getUniqueId());
+                    opt.ifPresent(activeMob -> pet.changeActiveMobTo(activeMob, (Player) player));
+
+                }
+            }.runTaskLater(MCPets.getInstance(), 1L);
+
         }
         return SkillResult.SUCCESS;
     }

--- a/src/main/java/fr/nocsy/mcpets/utils/BukkitSerialization.java
+++ b/src/main/java/fr/nocsy/mcpets/utils/BukkitSerialization.java
@@ -1,0 +1,220 @@
+package fr.nocsy.mcpets.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+import org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
+
+public class BukkitSerialization {
+
+    /**
+     * Converts the player inventory to a String array of Base64 strings. First string is the content and second string is the armor.
+     *
+     * @param playerInventory to turn into an array of strings.
+     * @return Array of strings: [ main content, armor content ]
+     * @throws IllegalStateException
+     */
+    public static String[] playerInventoryToBase64(PlayerInventory playerInventory) throws IllegalStateException {
+        //get the main content part, this doesn't return the armor
+        String content = toBase64(playerInventory);
+        String armor = itemStackArrayToBase64(playerInventory.getArmorContents());
+
+        return new String[] { content, armor };
+    }
+
+    /**
+     *
+     * A method to serialize an {@link ItemStack} array to Base64 String.
+     *
+     * <p />
+     *
+     * Based off of {@link #toBase64(Inventory)}.
+     *
+     * @param items to turn into a Base64 String.
+     * @return Base64 string of the items.
+     * @throws IllegalStateException
+     */
+    public static String itemStackArrayToBase64(ItemStack[] items) throws IllegalStateException {
+        try {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream);
+
+            // Write the size of the inventory
+            dataOutput.writeInt(items.length);
+
+            // Save every element in the list
+            for (int i = 0; i < items.length; i++) {
+                dataOutput.writeObject(items[i]);
+            }
+
+            // Serialize that array
+            dataOutput.close();
+            return Base64Coder.encodeLines(outputStream.toByteArray());
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to save item stacks.", e);
+        }
+    }
+
+    /**
+     * A method to serialize an inventory to Base64 string.
+     *
+     * <p />
+     *
+     * Special thanks to Comphenix in the Bukkit forums or also known
+     * as aadnk on GitHub.
+     *
+     * <a href="https://gist.github.com/aadnk/8138186">Original Source</a>
+     *
+     * @param inventory to serialize
+     * @return Base64 string of the provided inventory
+     * @throws IllegalStateException
+     */
+    public static String toBase64(Inventory inventory) throws IllegalStateException {
+        try {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream);
+
+            // Write the size of the inventory
+            dataOutput.writeInt(inventory.getSize());
+
+            // Save every element in the list
+            for (int i = 0; i < inventory.getSize(); i++) {
+                dataOutput.writeObject(inventory.getItem(i));
+            }
+
+            // Serialize that array
+            dataOutput.close();
+            return Base64Coder.encodeLines(outputStream.toByteArray());
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to save item stacks.", e);
+        }
+    }
+
+    /**
+     * A method to serialize an item to Base64 string.
+     *
+     * <p />
+     *
+     * Special thanks to Comphenix in the Bukkit forums or also known
+     * as aadnk on GitHub.
+     *
+     * <a href="https://gist.github.com/aadnk/8138186">Original Source</a>
+     *
+     * @param item to serialize
+     * @return Base64 string of the provided inventory
+     * @throws IllegalStateException
+     */
+    public static String toBase64(ItemStack item) throws IllegalStateException {
+        try {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream);
+
+            dataOutput.writeObject(item);
+
+            // Serialize that array
+            dataOutput.close();
+            return Base64Coder.encodeLines(outputStream.toByteArray());
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to save item stacks.", e);
+        }
+    }
+
+    /**
+     *
+     * A method to get an {@link Inventory} from an encoded, Base64, string.
+     *
+     * <p />
+     *
+     * Special thanks to Comphenix in the Bukkit forums or also known
+     * as aadnk on GitHub.
+     *
+     * <a href="https://gist.github.com/aadnk/8138186">Original Source</a>
+     *
+     * @param data Base64 string of data containing an inventory.
+     * @return Inventory created from the Base64 string.
+     * @throws IOException
+     */
+    public static Inventory fromBase64(String data) throws IOException {
+        try {
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64Coder.decodeLines(data));
+            BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
+            Inventory inventory = Bukkit.getServer().createInventory(null, dataInput.readInt());
+
+            // Read the serialized inventory
+            for (int i = 0; i < inventory.getSize(); i++) {
+                inventory.setItem(i, (ItemStack) dataInput.readObject());
+            }
+
+            dataInput.close();
+            return inventory;
+        } catch (ClassNotFoundException e) {
+            throw new IOException("Unable to decode class type.", e);
+        }
+    }
+
+    /**
+     *
+     * A method to get an item from an encoded, Base64, string.
+     *
+     * <p />
+     *
+     * Special thanks to Comphenix in the Bukkit forums or also known
+     * as aadnk on GitHub.
+     *
+     * <a href="https://gist.github.com/aadnk/8138186">Original Source</a>
+     *
+     * @param data Base64 string of data containing an inventory.
+     * @return item created from the Base64 string.
+     * @throws IOException
+     */
+    public static ItemStack itemFromBase64(String data) throws IOException {
+        try {
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64Coder.decodeLines(data));
+            BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
+
+            ItemStack item = (ItemStack) dataInput.readObject();
+
+            dataInput.close();
+            return item;
+        } catch (ClassNotFoundException e) {
+            throw new IOException("Unable to decode class type.", e);
+        }
+    }
+
+
+    /**
+     * Gets an array of ItemStacks from Base64 string.
+     *
+     * <p />
+     *
+     * Base off of {@link #fromBase64(String)}.
+     *
+     * @param data Base64 string to convert to ItemStack array.
+     * @return ItemStack array created from the Base64 string.
+     * @throws IOException
+     */
+    public static ItemStack[] itemStackArrayFromBase64(String data) throws IOException {
+        try {
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64Coder.decodeLines(data));
+            BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
+            ItemStack[] items = new ItemStack[dataInput.readInt()];
+
+            // Read the serialized inventory
+            for (int i = 0; i < items.length; i++) {
+                items[i] = (ItemStack) dataInput.readObject();
+            }
+
+            dataInput.close();
+            return items;
+        } catch (ClassNotFoundException e) {
+            throw new IOException("Unable to decode class type.", e);
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: MCPets
 main: fr.nocsy.mcpets.MCPets
-version: 1.0.4
+version: 2.0.0
 description: More info at MCModels.net
 depends:
   - MythicMobs


### PR DESCRIPTION
## ⏳ Small changes & new features ##
- ✅ Possibility to hide the "Signal stick" even when the pet has signals available
  - ✅ Change the way signal sticks are currently handle to refer to a type of pet
  - ✅ Command to give oneself the signal stick (/mcpets signalsticks <player> <pet>)
  - ✅ Command to turn the player in hand item into a signal stick for a specific pet (/mcpets signalsticks <pet>)
  - ✅ Option to enable the "Signal Stick from the Menu" in the config 
- ❌ Show skill on cooldown
  - Requires a skill to be triggered from MM coz of possible delays and cancel etc...
  - So it requires vendors to edit all their products to adapt it to the new system, or it won't show any cooldown
- ✅ Create pet categories to show up in a menu when doing /mcpets, then it opens category menus (it'll help for selecting "living" from "cosmetic" pets)
  - ✅ Added a custom metadata (960) to the pager system
- ✅ Possibility to change all the icons in the interaction menu
  - ✅ Add the icons to the "itemsList.yml"
- ✅ Disable pets in worlds
  - ✅ Add a world blacklist
- ✅ Add a mechanic to set a certain Mythic Mobs as a Pet (so you can summon pets not only through the menu, but other processes eventually)
- ❌ Add a flat SQL support
- Add multi-server support to keep pets spawned between servers
- ✅ Add an option to prevent the player to open the interaction menu when holding a signal stick
- ✅ Option to disable MySQL from config
- ✅ Add a silent check to the pet command (/pets spawn <id> <player> true -s / (-s) being the optional silent argument)
- ✅ Add mechanic to switch the pet behavior (PetFollow mechanic)
- ✅ Turn off/on the prefix in the language.yml file (just put "" if you want no prefix)
- ✅ Turn off default name to keep MM naming system

## ✅ Inventory system ##
- ✅ Possibility to store items in the pet inventory if enabled
  - ✅ Define default inventory size for each pet
    - ⏳ make it work with the evolving system in which a pet can eventually add up space in this inventory
  - ✅ Stock inventory into the DB
  - ✅ Icon in the pet menu interaction

## ✅ Skins system ##
- ✅ In the pet interaction menu, you can select a skin (if enabled)  
  - ✅ Define a list of skins (models) for a specific pet (in the pet file)
    - ✅ Permission for each skin
  - ✅ Create an in game menu to show the available skins