### PR TITLE
feat: add vanilla event for mount and dismount

### DIFF
--- a/src/main/java/fr/nocsy/mcpets/data/Pet.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Pet.java
@@ -846,9 +846,6 @@ public class Pet {
         if (ent == null)
             return;
 
-        EntityDismountEvent vanillaDismountEvent = new EntityDismountEvent(ent, activeMob.getEntity().getBukkitEntity());
-        Utils.callEvent(vanillaDismountEvent);
-
         // Try - catch to prevent onDisable no class def found print
         try {
             if (isStillHere()) {
@@ -859,6 +856,9 @@ public class Pet {
                 }
                 IMountHandler localIMountHandler = localModeledEntity.getMountHandler();
                 localIMountHandler.dismountAll();
+
+                EntityDismountEvent vanillaDismountEvent = new EntityDismountEvent(ent, activeMob.getEntity().getBukkitEntity());
+                Utils.callEvent(vanillaDismountEvent);
             }
 
         } catch (NoClassDefFoundError ignored) {

--- a/src/main/java/fr/nocsy/mcpets/data/Pet.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Pet.java
@@ -29,6 +29,8 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
+import org.spigotmc.event.entity.EntityDismountEvent;
+import org.spigotmc.event.entity.EntityMountEvent;
 
 import java.util.*;
 
@@ -784,9 +786,11 @@ public class Pet {
      */
     public boolean setMount(Entity ent) {
         EntityMountPetEvent event = new EntityMountPetEvent(ent, this);
+        EntityMountEvent vanillaMountEvent = new EntityMountEvent(ent, activeMob.getEntity().getBukkitEntity());
+        Utils.callEvent(vanillaMountEvent);
         Utils.callEvent(event);
 
-        if (event.isCancelled())
+        if (event.isCancelled() || vanillaMountEvent.isCancelled())
             return false;
 
         if (isStillHere()) {
@@ -841,6 +845,9 @@ public class Pet {
     public void dismount(Entity ent) {
         if (ent == null)
             return;
+
+        EntityDismountEvent vanillaDismountEvent = new EntityDismountEvent(ent, activeMob.getEntity().getBukkitEntity());
+        Utils.callEvent(vanillaDismountEvent);
 
         // Try - catch to prevent onDisable no class def found print
         try {

--- a/src/main/java/fr/nocsy/mcpets/listeners/EventListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/EventListener.java
@@ -20,6 +20,7 @@ public class EventListener implements Listener {
         listeners.add(new PetInventoryListener());
         listeners.add(new SignalStickListener());
         listeners.add(new PetSkinsMenuListener());
+        listeners.add(new VanillaDismountListener());
 
         listeners.add(new MythicListener());
 

--- a/src/main/java/fr/nocsy/mcpets/listeners/VanillaDismountListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/VanillaDismountListener.java
@@ -1,0 +1,42 @@
+package fr.nocsy.mcpets.listeners;
+
+import java.util.UUID;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.spigotmc.event.entity.EntityDismountEvent;
+
+import com.ticxo.modelengine.api.ModelEngineAPI;
+import com.ticxo.modelengine.api.model.ModeledEntity;
+
+public class VanillaDismountListener implements Listener {
+	
+	@EventHandler
+	public void onDismount(EntityDismountEvent e) {
+		var entity = e.getEntity();
+		if (!(entity instanceof Player)) {
+			return;
+		}
+
+		UUID petUUID = e.getDismounted().getUniqueId();
+
+		ModeledEntity localModeledEntity = ModelEngineAPI.api.getModelManager().getModeledEntity(petUUID);
+		if (localModeledEntity == null) {
+			return;
+		}
+
+		var mountManager = localModeledEntity.getMountHandler();
+		var driver = mountManager.getDriver();
+		if (driver == null) {
+			mountManager.removePassenger(entity);
+			return;
+		}
+
+		if (driver.getUniqueId().equals(entity.getUniqueId())) {
+			mountManager.dismountAll();
+		} else {
+			mountManager.removePassenger(entity);
+		}
+	}
+}


### PR DESCRIPTION
**What does it do?**
- Sends a vanilla EntityMount event so plugins listening to this could work correctly
- Listens to the EntityDismount event and dismount with ModelEngine