### PR TITLE
MCPets Database syncing fix

### DIFF
--- a/src/main/java/fr/nocsy/mcpets/data/Category.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Category.java
@@ -1,17 +1,14 @@
 package fr.nocsy.mcpets.data;
 
-import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.data.config.FormatArg;
 import fr.nocsy.mcpets.data.config.Language;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Cat;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.metadata.FixedMetadataValue;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/fr/nocsy/mcpets/data/Pet.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Pet.java
@@ -12,6 +12,7 @@ import fr.nocsy.mcpets.data.config.GlobalConfig;
 import fr.nocsy.mcpets.data.config.Language;
 import fr.nocsy.mcpets.data.livingpets.PetLevel;
 import fr.nocsy.mcpets.data.livingpets.PetStats;
+import fr.nocsy.mcpets.data.sql.Databases;
 import fr.nocsy.mcpets.data.sql.PlayerData;
 import fr.nocsy.mcpets.events.*;
 import fr.nocsy.mcpets.utils.PathFindingUtils;
@@ -946,6 +947,9 @@ public class Pet {
                     activeMob.getEntity().getBukkitEntity().remove();
             }
 
+            if(GlobalConfig.getInstance().isDatabaseSupport()) {
+                Databases.savePlayerData(ownerPlayer.getUniqueId());
+            }
             activePets.remove(owner);
             return true;
         }

--- a/src/main/java/fr/nocsy/mcpets/data/Pet.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Pet.java
@@ -948,7 +948,7 @@ public class Pet {
             }
 
             if(GlobalConfig.getInstance().isDatabaseSupport()) {
-                Databases.savePlayerData(ownerPlayer.getUniqueId());
+                Databases.savePlayerData(owner);
             }
             activePets.remove(owner);
             return true;

--- a/src/main/java/fr/nocsy/mcpets/data/livingpets/PetStats.java
+++ b/src/main/java/fr/nocsy/mcpets/data/livingpets/PetStats.java
@@ -282,8 +282,8 @@ public class PetStats {
         if(levelUp)
         {
             updateChangingData();
-            save();
         }
+        save();
 
         // If there is no next level, set the experience so that it's the plateau value
         if(getNextLevel().equals(currentLevel) && experience > currentLevel.getExpThreshold())
@@ -355,21 +355,14 @@ public class PetStats {
      * Save the stats in the database
      * Runs async for SQL, runs sync otherwise coz YAML doesn't support async
      */
-    public void save()
-    {
-        if(GlobalConfig.getInstance().isDatabaseSupport())
-        {
-            new Thread(new Runnable() {
-                public void run() {
-                    PlayerData.saveDB();
-                }
-            }).start();
-        }
-        else
-        {
+    public void save() {
+        if (GlobalConfig.getInstance().isDatabaseSupport()) {
+            PlayerData.saveDB();
+        } else {
             PlayerData pd = PlayerData.get(pet.getOwner());
-            if(pd != null)
+            if (pd != null) {
                 pd.save();
+            }
         }
     }
 
@@ -450,16 +443,14 @@ public class PetStats {
     /**
      * Save all pet stats asynchronously on a regular time period
      */
-    public static void saveStats()
-    {
+    public static void saveStats() {
         // Get the auto save delay (in seconds) and transform it into ticks
         long delay = (long)GlobalConfig.getInstance().getAutoSave()*20;
         // If the delay is negative, disable the autosave
         if(delay <= 0)
             return;
         // Runs ASync if it's a SQL, sync if not coz YAML doesn't support ASync
-        if(GlobalConfig.getInstance().isDatabaseSupport())
-        {
+        if(GlobalConfig.getInstance().isDatabaseSupport()) {
             Bukkit.getScheduler().scheduleAsyncRepeatingTask(MCPets.getInstance(), new Runnable() {
                 @Override
                 public void run() {
@@ -467,8 +458,7 @@ public class PetStats {
                 }
             }, delay, delay);
         }
-        else
-        {
+        else {
             Bukkit.getScheduler().scheduleSyncRepeatingTask(MCPets.getInstance(), new Runnable() {
                 @Override
                 public void run() {
@@ -476,8 +466,8 @@ public class PetStats {
                 }
             }, delay, delay);
         }
-
     }
+
 
     /**
      * Find the pet stats corresponding to the pet and the defined owner if registered
@@ -524,6 +514,21 @@ public class PetStats {
     public static PetStats getPetStatsOnRespawnTimerRunning(UUID uuid)
     {
         return petStatsList.stream().filter(petStats -> petStats.getPet().getOwner().equals(uuid) && petStats.isRespawnTimerRunning()).findFirst().orElse(null);
+    }
+
+    /**
+     * Set the pet's stats values.
+     * @param experience
+     * @param currentHealth
+     * @param currentLevel
+     */
+    public void setStats(double experience, double currentHealth, PetLevel currentLevel) {
+        this.experience = experience;
+        this.currentHealth = currentHealth;
+        this.currentLevel = currentLevel;
+
+        updateChangingData();
+        launchRegenerationTimer();
     }
 
 }

--- a/src/main/java/fr/nocsy/mcpets/data/sql/PlayerData.java
+++ b/src/main/java/fr/nocsy/mcpets/data/sql/PlayerData.java
@@ -7,21 +7,22 @@ import lombok.Setter;
 
 import java.util.HashMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class PlayerData {
 
     @Getter
-    private static final HashMap<UUID, PlayerData> registeredData = new HashMap<>();
+    private static final ConcurrentHashMap<UUID, PlayerData> registeredData = new ConcurrentHashMap<>();
 
     @Getter
     @Setter
-    private HashMap<String, String> mapOfRegisteredNames = new HashMap<>();
+    private ConcurrentHashMap<String, String> mapOfRegisteredNames = new ConcurrentHashMap<>();
     @Getter
     @Setter
-    private HashMap<String, String> mapOfRegisteredInventories = new HashMap<>();
+    private ConcurrentHashMap<String, String> mapOfRegisteredInventories = new ConcurrentHashMap<>();
     @Getter
     @Setter
-    private HashMap<String, String> mapOfRegisteredPetStats = new HashMap<>();
+    private ConcurrentHashMap<String, String> mapOfRegisteredPetStats = new ConcurrentHashMap<>();
 
     @Setter
     @Getter
@@ -29,8 +30,6 @@ public class PlayerData {
 
     private PlayerData(UUID uuid) {
         this.uuid = uuid;
-        init();
-        save();
     }
 
     private PlayerData() {
@@ -64,8 +63,8 @@ public class PlayerData {
         return data;
     }
 
-    public static void initAll() {
-        reloadAll();
+    public static void initializeAllPlayerData() {
+        reloadAllPlayerData();
     }
 
     public static void saveDB() {
@@ -77,12 +76,8 @@ public class PlayerData {
         }
     }
 
-    public static void reloadAll() {
+    public static void reloadAllPlayerData() {
         Databases.loadData();
-    }
-
-    public void init() {
-        reload();
     }
 
     /**
@@ -113,6 +108,22 @@ public class PlayerData {
 
             pdn.setMapOfRegisteredInventories(mapOfRegisteredInventories);
             pdn.save();
+        }
+    }
+
+    public static void initAll() {
+        if (GlobalConfig.getInstance().isDatabaseSupport()) {
+            Databases.loadData();
+        } else {
+            PlayerDataNoDatabase.getCacheMap().values().forEach(PlayerDataNoDatabase::reload);
+        }
+    }
+
+    public static void reloadAll(UUID uuid) {
+        if (GlobalConfig.getInstance().isDatabaseSupport()) {
+            Databases.loadData(uuid);
+        } else {
+            PlayerDataNoDatabase.get(uuid).reload();
         }
     }
 

--- a/src/main/java/fr/nocsy/mcpets/data/sql/PlayerDataNoDatabase.java
+++ b/src/main/java/fr/nocsy/mcpets/data/sql/PlayerDataNoDatabase.java
@@ -9,20 +9,20 @@ import lombok.Setter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.UUID;
-import java.util.stream.Collectors;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class PlayerDataNoDatabase extends AbstractConfig {
 
     @Getter
-    private static final HashMap<UUID, PlayerDataNoDatabase> cacheMap = new HashMap<>();
+    private static final ConcurrentHashMap<UUID, PlayerDataNoDatabase> cacheMap = new ConcurrentHashMap<>();
     @Getter
     private final UUID uuid;
     @Getter
     @Setter
-    public HashMap<String, String> mapOfRegisteredNames = new HashMap<>();
+    public ConcurrentHashMap<String, String> mapOfRegisteredNames = new ConcurrentHashMap<>();
     @Getter
     @Setter
-    public HashMap<String, String> mapOfRegisteredInventories = new HashMap<>();
+    public ConcurrentHashMap<String, String> mapOfRegisteredInventories = new ConcurrentHashMap<>();
 
     private PlayerDataNoDatabase(UUID uuid) {
         this.uuid = uuid;

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
@@ -14,6 +14,7 @@ import fr.nocsy.mcpets.data.flags.DismountPetFlag;
 import fr.nocsy.mcpets.data.flags.FlagsManager;
 import fr.nocsy.mcpets.data.inventories.PetInteractionMenu;
 import fr.nocsy.mcpets.data.livingpets.PetFood;
+import fr.nocsy.mcpets.data.sql.Databases;
 import fr.nocsy.mcpets.data.sql.PlayerData;
 import fr.nocsy.mcpets.events.EntityMountPetEvent;
 import fr.nocsy.mcpets.events.PetOwnerInteractEvent;
@@ -27,6 +28,7 @@ import org.bukkit.GameMode;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -123,30 +125,48 @@ public class PetListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void disconnectPlayer(PlayerQuitEvent e) {
         Player p = e.getPlayer();
         if (Pet.getActivePets().containsKey(p.getUniqueId()) && GlobalConfig.getInstance().isSpawnPetOnReconnect()) {
             Pet pet = Pet.getActivePets().get(p.getUniqueId());
-            pet.despawn(PetDespawnReason.DISCONNECTION);
-            reconnectionPets.put(p.getUniqueId(), pet);
 
             // Saving the database for bungee support
-            if(GlobalConfig.getInstance().isDatabaseSupport())
-            {
-                PlayerData.saveDB();
+            if(GlobalConfig.getInstance().isDatabaseSupport()) {
+                Databases.savePlayerData(p.getUniqueId());
             }
+
+            // delay before despawning the pet and adding it to reconnectionPets
+            Bukkit.getScheduler().runTaskLater(MCPets.getInstance(), () -> {
+                pet.despawn(PetDespawnReason.DISCONNECTION);
+                reconnectionPets.put(p.getUniqueId(), pet);
+            }, 20L);
         }
     }
 
-    @EventHandler
+
+    @EventHandler(priority = EventPriority.MONITOR)
     public void reconnectionPlayer(PlayerJoinEvent e) {
         Player p = e.getPlayer();
-        if (reconnectionPets.containsKey(p.getUniqueId())) {
-            Pet pet = reconnectionPets.get(p.getUniqueId());
-            pet.spawn(p.getLocation(), true);
-            reconnectionPets.remove(p.getUniqueId());
-        }
+
+        // delay before loading the player data from the database
+        Bukkit.getScheduler().runTaskLater(MCPets.getInstance(), () -> {
+            // Load the player data from the database for bungee support
+            if (GlobalConfig.getInstance().isDatabaseSupport()) {
+                PlayerData.reloadAll(p.getUniqueId());
+            }
+
+            if (reconnectionPets.containsKey(p.getUniqueId())) {
+                Pet pet = reconnectionPets.get(p.getUniqueId());
+                pet.spawn(p.getLocation(), true);
+                reconnectionPets.remove(p.getUniqueId());
+
+                // Save the player data after reconnecting
+                if (GlobalConfig.getInstance().isDatabaseSupport()) {
+                    PlayerData.saveDB();
+                }
+            }
+        }, 20L);
     }
 
     @EventHandler


### PR DESCRIPTION
- Replaced Hashmaps to ConcurrentHashMaps since they're thread-safe and internally synced.
- Added a new method ``reloadAll(uuid)`` to reload specific player data and not all players.
- Added a delay and changed the way login/quit logic is for saving playerdata
- ``addExperience(double)`` now saves even if not able to level up to sync exp daa
- Now Databases class uses locks to load/save to ensure there's no race-condition
- And other changes/clean up