### PR TITLE
Bump compiler and dependencies, add repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
@@ -33,7 +33,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.36</version>
+                            <version>1.18.44</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -94,6 +94,10 @@
             <id>nexo-repo</id>
             <url>https://repo.nexomc.com/releases</url>
         </repository>
+        <repository>
+            <id>matteodev</id>
+            <url>https://maven.devs.beer/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -101,13 +105,13 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.36</version>
+            <version>1.18.44</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>2.13.2</version>
         </dependency>
 
         <!-- Minecraft dependencies -->
@@ -128,54 +132,58 @@
         <dependency>
             <groupId>io.lumine</groupId>
             <artifactId>Mythic-Dist</artifactId>
-            <version>5.9.0-SNAPSHOT</version>
+            <version>5.9.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
-            <version>7.0.7-SNAPSHOT</version>
+            <version>7.0.15</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.6</version>
+            <version>2.12.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.luckperms</groupId>
             <artifactId>api</artifactId>
-            <version>5.4</version>
+            <version>5.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ticxo.modelengine</groupId>
             <artifactId>ModelEngine</artifactId>
-            <version>R4.0.6</version>
+            <version>R4.0.9</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.github.toxicity188</groupId>
             <artifactId>bettermodel-bukkit-api</artifactId>
-            <version>2.0.1</version>
+            <version>2.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.LoneDev6</groupId>
+            <groupId>dev.lone</groupId>
             <artifactId>api-itemsadder</artifactId>
-            <version>3.6.1</version>
+            <version>4.0.10</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.nexomc</groupId>
             <artifactId>nexo</artifactId>
-            <version>1.1.0</version>
+            <version>1.21.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>net.byteflux</groupId>
                     <artifactId>libby-bukkit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>dev.triumphteam</groupId>
+                    <artifactId>triumph-gui</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Upgrade Maven build and dependencies: maven-compiler-plugin 3.14.1 -> 3.15.0 and update annotationProcessor Lombok to 1.18.44. Add new Maven repository (matteodev). Bump library versions (gson 2.8.9 -> 2.13.2, Mythic-Dist 5.9.0-SNAPSHOT -> 5.9.5, worldguard-bukkit 7.0.7-SNAPSHOT -> 7.0.15, placeholderapi 2.11.6 -> 2.12.2, luckperms api 5.4 -> 5.5, ModelEngine R4.0.6 -> R4.0.9, bettermodel-bukkit-api 2.0.1 -> 2.2.0). Change itemsadder coordinates (com.github.LoneDev6 -> dev.lone) and bump to 4.0.10. Update nexo to 1.21.0 and add an exclusion for dev.triumphteam:triumph-gui. These changes refresh dependencies and repository sources to resolve newer artifacts and maintain compatibility.