### PR TITLE
Refactor MythicMobs targeters, conditions and mechanics

### DIFF
--- a/src/main/java/fr/nocsy/mcpets/MCPets.java
+++ b/src/main/java/fr/nocsy/mcpets/MCPets.java
@@ -42,7 +42,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static fr.nocsy.mcpets.mythicmobs.MythicListener.PLACEHOLDER_PACKAGE;
+import static fr.nocsy.mcpets.mythicmobs.MythicListener.*;
 
 public class MCPets extends JavaPlugin {
 
@@ -156,7 +156,10 @@ public class MCPets extends JavaPlugin {
 
         // Register the placeholders
         componentRegistry = new CustomComponentRegistry(instance, Lists.newArrayList());
-        componentRegistry.registerCustomComponent(CustomComponentRegistry.MythicComponentType.PLACEHOLDER, PLACEHOLDER_PACKAGE);
+        componentRegistry.registerCustomComponent(CustomComponentRegistry.MythicComponentType.PLACEHOLDER, PLACEHOLDER_PACKAGE)
+                .registerCustomComponent(CustomComponentRegistry.MythicComponentType.CONDITION, CONDITION_PACKAGE)
+                .registerCustomComponent(CustomComponentRegistry.MythicComponentType.TARGETER, TARGETER_PACKAGE)
+                .registerCustomComponent(CustomComponentRegistry.MythicComponentType.MECHANIC, MECHANIC_PACKAGE);
 
         getLog().info("-=-=-=-= MCPets loaded =-=-=-=-");
         getLog().info("      Plugin made by Nocsy     ");

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/MythicListener.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/MythicListener.java
@@ -3,69 +3,27 @@ package fr.nocsy.mcpets.mythicmobs;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 
 import fr.nocsy.mcpets.MCPets;
-import fr.nocsy.mcpets.mythicmobs.mechanics.*;
-import fr.nocsy.mcpets.mythicmobs.targeters.TargeterPetOwner;
-import fr.nocsy.mcpets.mythicmobs.conditions.PetTamingCondition;
-import fr.nocsy.mcpets.mythicmobs.targeters.TargeterPetFromOwner;
-import fr.nocsy.mcpets.mythicmobs.conditions.PetExperienceCondition;
 
-import io.lumine.mythic.api.config.MythicLineConfig;
 import io.lumine.mythic.bukkit.events.MythicReloadedEvent;
 import io.lumine.mythic.core.skills.CustomComponentRegistry;
-import io.lumine.mythic.bukkit.events.MythicTargeterLoadEvent;
-import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
-import io.lumine.mythic.bukkit.events.MythicConditionLoadEvent;
 
 public class MythicListener implements Listener {
 
     public static final String PLACEHOLDER_PACKAGE = "fr.nocsy.mcpets.mythicmobs.placeholders";
+    public static final String CONDITION_PACKAGE = "fr.nocsy.mcpets.mythicmobs.conditions";
+    public static final String TARGETER_PACKAGE = "fr.nocsy.mcpets.mythicmobs.targeters";
+    public static final String MECHANIC_PACKAGE = "fr.nocsy.mcpets.mythicmobs.mechanics";
 
     @EventHandler
     public void onMythicReload(MythicReloadedEvent e) {
-        // load the placeholders
-        Bukkit.getScheduler().runTaskLater(MCPets.getInstance(), () ->
-                MCPets.getComponentRegistry().registerCustomComponent(
-                        CustomComponentRegistry.MythicComponentType.PLACEHOLDER, PLACEHOLDER_PACKAGE), 1L);
-    }
-
-    @EventHandler
-    public void onMythicEventLoad(MythicConditionLoadEvent e) {
-        MythicLineConfig config = e.getConfig();
-        switch (e.getConditionName().toLowerCase()) {
-            case "petexperience" -> e.register(new PetExperienceCondition(config.getLine(), config));
-            case "pettaming" -> e.register(new PetTamingCondition(config.getLine(), config));
-        }
-    }
-
-    @EventHandler
-    public void onMythicTargeterLoad(MythicTargeterLoadEvent e) {
-        MythicLineConfig config = e.getConfig();
-        switch (e.getTargeterName().toLowerCase()) {
-            case "petowner" -> e.register(new TargeterPetOwner(config));
-            case "petfromowner" -> e.register(new TargeterPetFromOwner(config));
-        }
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST)
-    public void onMythicMechanicLoad(MythicMechanicLoadEvent e) {
-        MythicLineConfig config = e.getConfig();
-        switch (e.getMechanicName().toLowerCase()) {
-            case "givepet" -> e.register(new GivePetMechanic(config));
-            case "setpet" -> e.register(new SetPetMechanic(config));
-            case "petfollow" -> e.register(new PetFollowMechanic(config));
-            case "petname" -> e.register(new PetNameMechanic(config));
-            case "petexperience" -> e.register(new PetExperienceMechanic(config));
-            case "petdamage" -> e.register(new PetDamageMechanic(config));
-            case "petbuff" -> e.register(new PetBuffMechanic(config));
-            case "setlivingpet" -> e.register(new SetLivingPetMechanic(config));
-            case "petdespawn" -> e.register(new PetDespawnMechanic(config));
-            case "evolvepet" -> e.register(new EvolvePetMechanic(config));
-            case "droppetinventory" -> e.register(new DropPetInventoryMechanic(config));
-            case "droppetitem" -> e.register(new DropPetItemMechanic(config));
-        }
+        Bukkit.getScheduler().runTask(MCPets.getInstance(), () -> MCPets.getComponentRegistry()
+            .registerCustomComponent(CustomComponentRegistry.MythicComponentType.PLACEHOLDER, PLACEHOLDER_PACKAGE)
+            .registerCustomComponent(CustomComponentRegistry.MythicComponentType.CONDITION, CONDITION_PACKAGE)
+            .registerCustomComponent(CustomComponentRegistry.MythicComponentType.TARGETER, TARGETER_PACKAGE)
+            .registerCustomComponent(CustomComponentRegistry.MythicComponentType.MECHANIC, MECHANIC_PACKAGE)
+        );
     }
 
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/conditions/PetExperienceCondition.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/conditions/PetExperienceCondition.java
@@ -1,35 +1,44 @@
 package fr.nocsy.mcpets.mythicmobs.conditions;
 
 import fr.nocsy.mcpets.data.Pet;
+
+import io.lumine.mythic.core.skills.SkillCondition;
 import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.api.config.MythicLineConfig;
-import io.lumine.mythic.api.skills.conditions.IEntityCondition;
 import io.lumine.mythic.bukkit.utils.numbers.RangedDouble;
-import io.lumine.mythic.core.skills.SkillCondition;
-import io.lumine.mythic.core.utils.annotations.MythicCondition;
 import io.lumine.mythic.core.utils.annotations.MythicField;
-import org.bukkit.entity.Entity;
+import io.lumine.mythic.api.skills.conditions.IEntityCondition;
+import io.lumine.mythic.bukkit.events.MythicConditionLoadEvent;
+import io.lumine.mythic.core.utils.annotations.MythicCondition;
 
-@MythicCondition(author="Nocsy",name="petExperience",description="Tests value of the experience of the pet")
+@MythicCondition(
+        author = "Nocsy",
+        name = "petExperience",
+        description = "Tests value of the experience of the pet"
+)
 public class PetExperienceCondition extends SkillCondition implements IEntityCondition {
 
-    @MythicField(name = "experience", aliases = {"exp"}, description = "The experience value to check")
+    @MythicField(
+            name = "experience",
+            aliases = {"exp"},
+            description = "The experience value to check"
+    )
     private RangedDouble experience;
 
-    public PetExperienceCondition(String line, MythicLineConfig mlc) {
-        super(line);
+    public PetExperienceCondition(MythicConditionLoadEvent event) {
+        super(event.getConfig().getLine());
+
+        MythicLineConfig mlc = event.getConfig();
 
         experience = new RangedDouble(mlc.getString(new String[]{"experience", "exp"}, conditionVar));
     }
 
     @Override
     public boolean check(AbstractEntity target) {
-        Entity e = target.getBukkitEntity();
-        Pet pet = Pet.getFromEntity(e);
-        if (pet != null && pet.getPetStats() != null) {
-            return experience.equals(pet.getPetStats().getExperience());
-        }
+        Pet pet = Pet.getFromEntity(target.getBukkitEntity());
 
-        return false;
+        return pet != null
+                && pet.getPetStats() != null
+                && experience.equals(pet.getPetStats().getExperience());
     }
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/conditions/PetTamingCondition.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/conditions/PetTamingCondition.java
@@ -1,35 +1,45 @@
 package fr.nocsy.mcpets.mythicmobs.conditions;
 
 import fr.nocsy.mcpets.data.Pet;
+
+import io.lumine.mythic.core.skills.SkillCondition;
 import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.api.config.MythicLineConfig;
-import io.lumine.mythic.api.skills.conditions.IEntityCondition;
 import io.lumine.mythic.bukkit.utils.numbers.RangedDouble;
-import io.lumine.mythic.core.skills.SkillCondition;
-import io.lumine.mythic.core.utils.annotations.MythicCondition;
 import io.lumine.mythic.core.utils.annotations.MythicField;
-import org.bukkit.entity.Entity;
+import io.lumine.mythic.api.skills.conditions.IEntityCondition;
+import io.lumine.mythic.core.utils.annotations.MythicCondition;
+import io.lumine.mythic.bukkit.events.MythicConditionLoadEvent;
 
-@MythicCondition(author="Nocsy",name="petTaming",description="Tests value of the taming of the pet")
+@MythicCondition(
+        author = "Nocsy",
+        name = "petTaming",
+        description = "Tests value of the taming of the pet"
+)
 public class PetTamingCondition extends SkillCondition implements IEntityCondition {
 
-    @MythicField(name = "taming", aliases = {"t"}, description = "The taming value to check")
+    @MythicField(
+            name = "taming",
+            aliases = {"t"},
+            description = "The taming value to check"
+    )
     private RangedDouble taming;
 
-    public PetTamingCondition(String line, MythicLineConfig mlc) {
-        super(line);
+    public PetTamingCondition(MythicConditionLoadEvent event) {
+        super(event.getConfig().getLine());
+
+        MythicLineConfig mlc = event.getConfig();
 
         taming = new RangedDouble(mlc.getString(new String[]{"taming", "t"}, conditionVar));
     }
 
     @Override
     public boolean check(AbstractEntity target) {
-        Entity e = target.getBukkitEntity();
-        Pet pet = Pet.getFromEntity(e);
-        if (pet != null && pet.getPetStats() != null) {
-            return taming.equals(pet.getTamingProgress());
-        }
+        Pet pet = Pet.getFromEntity(target.getBukkitEntity());
 
-        return false;
+        return pet != null
+                && pet.getPetStats() != null
+                && taming.equals(pet.getTamingProgress());
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/DropPetInventoryMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/DropPetInventoryMechanic.java
@@ -1,53 +1,62 @@
 package fr.nocsy.mcpets.mythicmobs.mechanics;
 
-import fr.nocsy.mcpets.MCPets;
-import fr.nocsy.mcpets.data.Pet;
-import fr.nocsy.mcpets.data.inventories.PetInventory;
-import fr.nocsy.mcpets.data.inventories.PetInventoryHolder;
-import io.lumine.mythic.api.adapters.AbstractEntity;
-import io.lumine.mythic.api.config.MythicLineConfig;
-import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
-import io.lumine.mythic.api.skills.SkillResult;
-import io.lumine.mythic.bukkit.BukkitAdapter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-public class DropPetInventoryMechanic implements ITargetedEntitySkill {
+import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.Pet;
+import fr.nocsy.mcpets.data.inventories.PetInventory;
+import fr.nocsy.mcpets.data.inventories.PetInventoryHolder;
 
-    public DropPetInventoryMechanic(MythicLineConfig config) {}
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 
+@MythicMechanic(
+        name = "dropPetInventory"
+)
+public class DropPetInventoryMechanic extends SkillMechanic implements ITargetedEntitySkill {
+
+    public DropPetInventoryMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+    }
+
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
-
         AbstractEntity ent = data.getCaster().getEntity();
 
         Pet pet = Pet.getFromEntity(ent.getBukkitEntity());
-        if (pet == null)
-            return SkillResult.CONDITION_FAILED;
+        if (pet == null) return SkillResult.CONDITION_FAILED;
 
         try {
             PetInventory petInventory = PetInventory.get(pet);
+
             if (petInventory != null) {
                 Inventory inv = petInventory.getInventory();
                 Location loc = BukkitAdapter.adapt(pet.getActiveMob().getLocation());
-                // Call the drop on sync so it can trigger events
+
                 Bukkit.getScheduler().runTask(MCPets.getInstance(), () -> {
-                    for (ItemStack it : inv.getContents()) {
-                        if(it != null)
-                            loc.getWorld().dropItemNaturally(loc, it);
+                    for (ItemStack item : inv.getContents()) {
+                        if (item == null) continue;
+                        loc.getWorld().dropItemNaturally(loc, item);
                     }
                 });
 
                 petInventory.setInventory(new PetInventoryHolder(inv.getSize(), PetInventoryHolder.Type.PET_INVENTORY_MENU).getInventory());
             }
-        }
-        catch (Exception ex) {
+        } catch (Exception ex) {
             MCPets.getLog().log(java.util.logging.Level.SEVERE, "Failed to drop pet inventory", ex);
             return SkillResult.CONDITION_FAILED;
         }
 
         return SkillResult.SUCCESS;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/DropPetItemMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/DropPetItemMechanic.java
@@ -1,43 +1,58 @@
 package fr.nocsy.mcpets.mythicmobs.mechanics;
 
-import fr.nocsy.mcpets.MCPets;
-import fr.nocsy.mcpets.data.config.ItemsListConfig;
-import io.lumine.mythic.api.adapters.AbstractEntity;
-import io.lumine.mythic.api.config.MythicLineConfig;
-import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
-import io.lumine.mythic.api.skills.SkillResult;
-import io.lumine.mythic.bukkit.BukkitAdapter;
+import java.util.concurrent.ThreadLocalRandom;
+
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Random;
+import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.config.ItemsListConfig;
 
-public class DropPetItemMechanic implements ITargetedEntitySkill {
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.config.MythicLineConfig;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 
-    String petItemId = "";
-    float percentage = 1.0f;
+@MythicMechanic(
+        name = "dropPetItem"
+)
+public class DropPetItemMechanic extends SkillMechanic implements ITargetedEntitySkill {
 
-    public DropPetItemMechanic(MythicLineConfig config) {
-        this.petItemId = config.getString(new String[]{"petItem"}, this.petItemId);
-        this.percentage = config.getFloat(new String[]{"chance"}, this.percentage);
+    private final String petItemId;
+    private final float percentage;
 
-        this.percentage = Math.max(Math.min(percentage, 1.0f), 0);
+    public DropPetItemMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+
+        MythicLineConfig config = event.getConfig();
+
+        petItemId = config.getString(new String[]{"petItem"}, "");
+        percentage = Math.clamp(config.getFloat(new String[]{"chance"}, 1.0f), 0.0f, 1.0f);
     }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
         Entity entity = BukkitAdapter.adapt(target);
 
-        ItemStack it = ItemsListConfig.getInstance().getItemStack(petItemId);
-        if (it != null) {
-            Random random = new Random();
-            if (random.nextFloat() <= percentage) {
-                // Call the drop on sync so it can trigger events
-                Bukkit.getScheduler().runTask(MCPets.getInstance(), () -> entity.getLocation().getWorld().dropItemNaturally(entity.getLocation(), it));
-            }
+        ItemStack item = ItemsListConfig.getInstance().getItemStack(petItemId);
+
+        if (item != null && ThreadLocalRandom.current().nextFloat() <= percentage) {
+            Bukkit.getScheduler().runTask(
+                    MCPets.getInstance(),
+                    () -> entity.getWorld().dropItemNaturally(
+                            entity.getLocation(),
+                            item
+                    )
+            );
         }
 
         return SkillResult.SUCCESS;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/EvolvePetMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/EvolvePetMechanic.java
@@ -1,27 +1,40 @@
 package fr.nocsy.mcpets.mythicmobs.mechanics;
 
-import fr.nocsy.mcpets.MCPets;
-import fr.nocsy.mcpets.data.Pet;
-import fr.nocsy.mcpets.utils.debug.Debugger;
-import io.lumine.mythic.api.adapters.AbstractEntity;
-import io.lumine.mythic.api.config.MythicLineConfig;
-import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
-import io.lumine.mythic.api.skills.SkillResult;
-import io.lumine.mythic.bukkit.BukkitAdapter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 
-public class EvolvePetMechanic implements ITargetedEntitySkill {
+import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.Pet;
+import fr.nocsy.mcpets.utils.debug.Debugger;
 
-    String evolutionId = "";
-    boolean forceEvolution = false;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.config.MythicLineConfig;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 
-    public EvolvePetMechanic(MythicLineConfig config) {
-        this.evolutionId = config.getString(new String[]{"evolutionId"}, this.evolutionId);
-        this.forceEvolution = config.getBoolean(new String[]{"force"}, this.forceEvolution);
+@MythicMechanic(
+        name = "evolvePet"
+)
+public class EvolvePetMechanic extends SkillMechanic implements ITargetedEntitySkill {
+
+    private final String evolutionId;
+    private final boolean forceEvolution;
+
+    public EvolvePetMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+
+        MythicLineConfig config = event.getConfig();
+
+        evolutionId = config.getString(new String[]{"evolutionId"}, "");
+        forceEvolution = config.getBoolean(new String[]{"force"}, false);
     }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
         Entity entity = BukkitAdapter.adapt(data.getCaster().getEntity());
 
@@ -29,16 +42,24 @@ public class EvolvePetMechanic implements ITargetedEntitySkill {
         Pet evolution = Pet.getFromId(evolutionId);
 
         Debugger.send("§6[Evolution Mechanic]:");
-        if (pet != null)
+        if (pet != null) {
             Debugger.send("§7- pet: §a" + pet.getId() + "§7 has pet stats ? §a" + (pet.getPetStats() != null));
+        }
+
         Debugger.send("§7- evolution: §a" + evolutionId + " exists ? §a" + (evolution != null));
 
         if (evolution != null && pet != null && pet.getPetStats() != null) {
-            // Call the experience gain on sync so it can trigger events
-            Bukkit.getScheduler().runTask(MCPets.getInstance(), () -> pet.getPetStats().getCurrentLevel().evolveTo(pet.getOwner(), forceEvolution, evolution));
+            Bukkit.getScheduler().runTask(
+                    MCPets.getInstance(),
+                    () -> pet.getPetStats()
+                            .getCurrentLevel()
+                            .evolveTo(pet.getOwner(), forceEvolution, evolution)
+            );
+
             return SkillResult.SUCCESS;
         }
 
         return SkillResult.CONDITION_FAILED;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/GivePetMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/GivePetMechanic.java
@@ -1,34 +1,50 @@
 package fr.nocsy.mcpets.mythicmobs.mechanics;
 
-import fr.nocsy.mcpets.data.Pet;
-import fr.nocsy.mcpets.utils.Utils;
-import io.lumine.mythic.api.adapters.AbstractEntity;
-import io.lumine.mythic.api.config.MythicLineConfig;
-import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
-import io.lumine.mythic.api.skills.SkillResult;
-import io.lumine.mythic.bukkit.BukkitAdapter;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
-public class GivePetMechanic implements ITargetedEntitySkill {
+import fr.nocsy.mcpets.data.Pet;
+import fr.nocsy.mcpets.utils.Utils;
 
-    private String petId;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.config.MythicLineConfig;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 
-    public GivePetMechanic(MythicLineConfig config) {
-        this.petId = config.getString(new String[]{"id"}, this.petId);
+@MythicMechanic(
+        name = "givePet"
+)
+public class GivePetMechanic extends SkillMechanic implements ITargetedEntitySkill {
+
+    private final String petId;
+
+    public GivePetMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+
+        MythicLineConfig config = event.getConfig();
+
+        petId = config.getString(new String[]{"id"}, "");
     }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
         Entity player = BukkitAdapter.adapt(target);
 
         if (player instanceof Player) {
             Pet pet = Pet.getFromId(petId);
-            if (pet == null)
+            if (pet == null) {
                 return SkillResult.CONDITION_FAILED;
+            }
+
             Utils.givePermission(player.getUniqueId(), pet.getPermission());
         }
 
         return SkillResult.SUCCESS;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetBuffMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetBuffMechanic.java
@@ -1,51 +1,79 @@
 package fr.nocsy.mcpets.mythicmobs.mechanics;
 
-import fr.nocsy.mcpets.MCPets;
-import fr.nocsy.mcpets.data.Pet;
-import fr.nocsy.mcpets.data.livingpets.PetFoodBuff;
-import fr.nocsy.mcpets.data.livingpets.PetFoodType;
-import fr.nocsy.mcpets.utils.PetMath;
-import io.lumine.mythic.api.adapters.AbstractEntity;
-import io.lumine.mythic.api.config.MythicLineConfig;
-import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
-import io.lumine.mythic.api.skills.SkillResult;
-import io.lumine.mythic.api.skills.placeholders.PlaceholderFloat;
-import io.lumine.mythic.api.skills.placeholders.PlaceholderInt;
-import io.lumine.mythic.bukkit.BukkitAdapter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 
-public class PetBuffMechanic implements ITargetedEntitySkill {
+import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.Pet;
+import fr.nocsy.mcpets.utils.PetMath;
+import fr.nocsy.mcpets.data.livingpets.PetFoodBuff;
+import fr.nocsy.mcpets.data.livingpets.PetFoodType;
 
-    private PlaceholderInt duration;
-    private PlaceholderFloat power;
-    private String operator;
-    private String type;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.config.MythicLineConfig;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.api.skills.placeholders.PlaceholderInt;
+import io.lumine.mythic.api.skills.placeholders.PlaceholderFloat;
+import io.lumine.mythic.core.skills.placeholders.PlaceholderContext;
 
-    public PetBuffMechanic(MythicLineConfig config) {
-        this.duration = config.getPlaceholderInteger(new String[]{"duration"}, 0);
-        this.power = config.getPlaceholderFloat(new String[]{"power"}, 0);
-        this.operator = config.getString(new String[]{"operator"}, "ADD");
-        this.type = config.getString(new String[]{"type"}, "BUFF_DAMAGE");
+@MythicMechanic(
+        name = "petBuff"
+)
+public class PetBuffMechanic extends SkillMechanic implements ITargetedEntitySkill {
+
+    private final PlaceholderInt duration;
+    private final PlaceholderFloat power;
+
+    private final String operator;
+    private final String type;
+
+    public PetBuffMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+
+        MythicLineConfig config = event.getConfig();
+
+        duration = config.getPlaceholderInteger(new String[]{"duration"}, 0);
+        power = config.getPlaceholderFloat(new String[]{"power"}, 0);
+
+        operator = config.getString(new String[]{"operator"}, "ADD");
+        type = config.getString(new String[]{"type"}, "BUFF_DAMAGE");
     }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
         Entity entity = BukkitAdapter.adapt(target);
 
         Pet pet = Pet.getFromEntity(entity);
-        if (pet != null && pet.getPetStats() != null) {
-            // Call the experience gain on sync so it can trigger events
-            final long durationValue = duration.get(data);
-            final float powerValue = power.get(data);
-            PetFoodType buffType = PetFoodType.get(type);
-            PetMath mathOperator = PetMath.get(operator);
-            Bukkit.getScheduler().runTask(MCPets.getInstance(), () -> {
-                PetFoodBuff buff = new PetFoodBuff(pet, buffType, powerValue, mathOperator, durationValue);
-                buff.apply();
-            });
-            return SkillResult.SUCCESS;
+        if (pet == null || pet.getPetStats() == null) {
+            return SkillResult.CONDITION_FAILED;
         }
-        return SkillResult.CONDITION_FAILED;
+
+        PlaceholderContext context = PlaceholderContext.builder()
+                .meta(data)
+                .entity(target)
+                .build();
+
+        final long durationValue = duration.get(context);
+        final float powerValue = power.get(context);
+
+        PetFoodType buffType = PetFoodType.get(type);
+        PetMath mathOperator = PetMath.get(operator);
+
+        Bukkit.getScheduler().runTask(
+                MCPets.getInstance(),
+                () -> {
+                    PetFoodBuff buff = new PetFoodBuff(pet, buffType, powerValue, mathOperator, durationValue);
+                    buff.apply();
+                }
+        );
+
+        return SkillResult.SUCCESS;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetDamageMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetDamageMechanic.java
@@ -1,44 +1,73 @@
 package fr.nocsy.mcpets.mythicmobs.mechanics;
 
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Damageable;
+
 import fr.nocsy.mcpets.data.Pet;
-import fr.nocsy.mcpets.events.PetDamageEvent;
 import fr.nocsy.mcpets.utils.Utils;
+import fr.nocsy.mcpets.events.PetDamageEvent;
+
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
 import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.api.config.MythicLineConfig;
 import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
-import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
 import io.lumine.mythic.api.skills.placeholders.PlaceholderDouble;
-import io.lumine.mythic.bukkit.BukkitAdapter;
-import org.bukkit.entity.Damageable;
-import org.bukkit.entity.Entity;
+import io.lumine.mythic.core.skills.placeholders.PlaceholderContext;
 
-public class PetDamageMechanic implements ITargetedEntitySkill {
+@MythicMechanic(
+        name = "petDamage"
+)
+public class PetDamageMechanic extends SkillMechanic implements ITargetedEntitySkill {
 
-    private PlaceholderDouble damage;
-    private boolean applyStats = true;
+    private final PlaceholderDouble damage;
+    private final boolean applyStats;
 
-    public PetDamageMechanic(MythicLineConfig config) {
-        this.damage = config.getPlaceholderDouble(new String[]{"damage"}, this.damage);
-        this.applyStats = config.getBoolean(new String[]{"applyStats"}, this.applyStats);
+    public PetDamageMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+
+        MythicLineConfig config = event.getConfig();
+
+        damage = config.getPlaceholderDouble(new String[]{"damage"}, 0);
+        applyStats = config.getBoolean(new String[]{"applyStats"}, true);
     }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
         Entity entity = BukkitAdapter.adapt(target);
         Entity caster = BukkitAdapter.adapt(data.getCaster().getEntity());
+
         Pet pet = Pet.getFromEntity(caster);
-
-        if (pet != null && entity instanceof Damageable) {
-            PetDamageEvent event = new PetDamageEvent(pet, pet.getPetStats().getModifiedAttackDamages(damage.get(data, target)));
-            Utils.callEvent(event);
-            if (event.isCancelled())
-                return SkillResult.CONDITION_FAILED;
-
-            ((Damageable) entity).damage(event.getDamageAmount(), caster);
-
-            return SkillResult.SUCCESS;
+        if (pet == null || !(entity instanceof Damageable damageable)) {
+            return SkillResult.CONDITION_FAILED;
         }
 
-        return SkillResult.CONDITION_FAILED;
+        PlaceholderContext context = PlaceholderContext.builder()
+                .meta(data)
+                .entity(target)
+                .build();
+
+        double damageAmount = damage.get(context);
+
+        if (applyStats) {
+            damageAmount = pet.getPetStats().getModifiedAttackDamages(damageAmount);
+        }
+
+        PetDamageEvent event = new PetDamageEvent(pet, damageAmount);
+
+        Utils.callEvent(event);
+
+        if (event.isCancelled()) {
+            return SkillResult.CONDITION_FAILED;
+        }
+
+        damageable.damage(event.getDamageAmount(), caster);
+
+        return SkillResult.SUCCESS;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetDespawnMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetDespawnMechanic.java
@@ -2,24 +2,36 @@ package fr.nocsy.mcpets.mythicmobs.mechanics;
 
 import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.PetDespawnReason;
-import io.lumine.mythic.api.adapters.AbstractEntity;
-import io.lumine.mythic.api.config.MythicLineConfig;
-import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
+
 import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 
-public class PetDespawnMechanic implements ITargetedEntitySkill {
+@MythicMechanic(
+        name = "petDespawn"
+)
+public class PetDespawnMechanic extends SkillMechanic implements ITargetedEntitySkill {
 
-    public PetDespawnMechanic(MythicLineConfig config) {}
+    public PetDespawnMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+    }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
-        AbstractEntity ent = data.getCaster().getEntity();
+        AbstractEntity entity = data.getCaster().getEntity();
 
-        Pet pet = Pet.getFromEntity(ent.getBukkitEntity());
-        if (pet == null)
+        Pet pet = Pet.getFromEntity(entity.getBukkitEntity());
+        if (pet == null) {
             return SkillResult.CONDITION_FAILED;
+        }
 
         pet.despawn(PetDespawnReason.PETDESPAWN_SKILL);
+
         return SkillResult.SUCCESS;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetExperienceMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetExperienceMechanic.java
@@ -1,35 +1,57 @@
 package fr.nocsy.mcpets.mythicmobs.mechanics;
 
-import fr.nocsy.mcpets.MCPets;
-import fr.nocsy.mcpets.data.Pet;
-import io.lumine.mythic.api.adapters.AbstractEntity;
-import io.lumine.mythic.api.config.MythicLineConfig;
-import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
-import io.lumine.mythic.api.skills.SkillResult;
-import io.lumine.mythic.api.skills.placeholders.PlaceholderDouble;
-import io.lumine.mythic.bukkit.BukkitAdapter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 
-public class PetExperienceMechanic implements ITargetedEntitySkill {
+import fr.nocsy.mcpets.MCPets;
+import fr.nocsy.mcpets.data.Pet;
 
-    PlaceholderDouble experience;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.config.MythicLineConfig;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
+import io.lumine.mythic.api.skills.placeholders.PlaceholderDouble;
+import io.lumine.mythic.core.skills.placeholders.PlaceholderContext;
 
-    public PetExperienceMechanic(MythicLineConfig config) {
-        this.experience = config.getPlaceholderDouble(new String[]{"exp"}, 0.0D);
+@MythicMechanic(
+        name = "petExperience"
+)
+public class PetExperienceMechanic extends SkillMechanic implements ITargetedEntitySkill {
+
+    private final PlaceholderDouble experience;
+
+    public PetExperienceMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+
+        MythicLineConfig config = event.getConfig();
+
+        experience = config.getPlaceholderDouble(new String[]{"exp"}, 0.0D);
     }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
         Entity entity = BukkitAdapter.adapt(target);
 
         Pet pet = Pet.getFromEntity(entity);
-        if (pet != null && pet.getPetStats() != null) {
-            // Call the experience gain on sync so it can trigger events
-            final double expValue = experience.get(data);
-            Bukkit.getScheduler().runTask(MCPets.getInstance(), () -> pet.getPetStats().addExperience(expValue));
-            return SkillResult.SUCCESS;
+        if (pet == null || pet.getPetStats() == null) {
+            return SkillResult.CONDITION_FAILED;
         }
-        return SkillResult.CONDITION_FAILED;
+
+        PlaceholderContext context = PlaceholderContext.builder()
+                .meta(data)
+                .entity(target)
+                .build();
+
+        final double expValue = experience.get(context);
+
+        Bukkit.getScheduler().runTask(MCPets.getInstance(), () -> pet.getPetStats().addExperience(expValue));
+
+        return SkillResult.SUCCESS;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetFollowMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetFollowMechanic.java
@@ -1,30 +1,46 @@
 package fr.nocsy.mcpets.mythicmobs.mechanics;
 
+import org.bukkit.entity.Entity;
+
 import fr.nocsy.mcpets.data.Pet;
+
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
 import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.api.config.MythicLineConfig;
 import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
-import io.lumine.mythic.api.skills.SkillResult;
-import io.lumine.mythic.bukkit.BukkitAdapter;
-import org.bukkit.entity.Entity;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 
-public class PetFollowMechanic implements ITargetedEntitySkill {
+@MythicMechanic(
+        name = "petFollow"
+)
+public class PetFollowMechanic extends SkillMechanic implements ITargetedEntitySkill {
 
-    boolean follow = true;
+    private final boolean follow;
 
-    public PetFollowMechanic(MythicLineConfig config) {
-        this.follow = config.getBoolean(new String[]{"follow"}, this.follow);
+    public PetFollowMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+
+        MythicLineConfig config = event.getConfig();
+
+        follow = config.getBoolean(new String[]{"follow"}, true);
     }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
         Entity entity = BukkitAdapter.adapt(target);
 
         Pet pet = Pet.getFromEntity(entity);
-        if (pet != null) {
-            pet.setFollowOwner(follow);
-            return SkillResult.SUCCESS;
+        if (pet == null) {
+            return SkillResult.CONDITION_FAILED;
         }
-        return SkillResult.CONDITION_FAILED;
+
+        pet.setFollowOwner(follow);
+
+        return SkillResult.SUCCESS;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetNameMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/PetNameMechanic.java
@@ -7,24 +7,39 @@ import fr.nocsy.mcpets.data.Pet;
 import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.api.skills.SkillResult;
 import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
 import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.api.config.MythicLineConfig;
 import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 
-public class PetNameMechanic implements ITargetedEntitySkill {
+@MythicMechanic(
+        name = "petName"
+)
+public class PetNameMechanic extends SkillMechanic implements ITargetedEntitySkill {
 
-    private String petName;
-    private boolean save;
+    private final String petName;
+    private final boolean save;
 
-    public PetNameMechanic(MythicLineConfig config) {
-        this.petName = config.getString(new String[]{"name"}, "No name");
-        this.save =  config.getBoolean(new String[]{"save"}, false);
+    public PetNameMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+
+        MythicLineConfig config = event.getConfig();
+
+        petName = config.getString(new String[]{"name"}, "No name");
+        save = config.getBoolean(new String[]{"save"}, false);
     }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
         Entity petEntity = BukkitAdapter.adapt(target);
+
         Pet pet = Pet.getFromEntity(petEntity);
-        if (pet == null) return SkillResult.CONDITION_FAILED;
+        if (pet == null) {
+            return SkillResult.CONDITION_FAILED;
+        }
+
         pet.setDisplayName(petName, save);
 
         return SkillResult.SUCCESS;

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/SetLivingPetMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/SetLivingPetMechanic.java
@@ -1,51 +1,67 @@
 package fr.nocsy.mcpets.mythicmobs.mechanics;
 
+import java.util.Optional;
+
+import org.bukkit.Bukkit;
+
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.data.Pet;
+
+import io.lumine.mythic.core.mobs.ActiveMob;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
 import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.api.config.MythicLineConfig;
 import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
-import io.lumine.mythic.api.skills.SkillResult;
-import io.lumine.mythic.core.mobs.ActiveMob;
-import org.bukkit.scheduler.BukkitRunnable;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 
-import java.util.Optional;
+@MythicMechanic(
+        name = "setLivingPet"
+)
+public class SetLivingPetMechanic extends SkillMechanic implements ITargetedEntitySkill {
 
-public class SetLivingPetMechanic implements ITargetedEntitySkill {
+    private final String petId;
+    private final boolean followOnTame;
+    private final double tamingProgress;
 
-    private String petId;
-    private boolean followOnTame = true;
-    private double tamingProgress = 0;
+    public SetLivingPetMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
 
-    public SetLivingPetMechanic(MythicLineConfig config) {
-        this.petId = config.getString(new String[]{"id"}, this.petId);
-        this.followOnTame = config.getBoolean(new String[]{"followOnTame", "foT"}, this.followOnTame);
-        this.tamingProgress = config.getDouble(new String[]{"tamingProgress", "tP"}, this.tamingProgress);
+        MythicLineConfig config = event.getConfig();
+
+        petId = config.getString(new String[]{"id"}, "");
+        followOnTame = config.getBoolean(new String[]{"followOnTame", "foT"}, true);
+        tamingProgress = config.getDouble(new String[]{"tamingProgress", "tP"}, 0.0D);
     }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
-        AbstractEntity ent = data.getCaster().getEntity();
+        AbstractEntity entity = data.getCaster().getEntity();
 
-        if (Pet.getFromEntity(ent.getBukkitEntity()) != null)
+        if (Pet.getFromEntity(entity.getBukkitEntity()) != null) {
             return SkillResult.CONDITION_FAILED;
+        }
 
         Pet pet = Pet.getFromId(petId);
-        if (pet == null)
+        if (pet == null) {
             return SkillResult.CONDITION_FAILED;
+        }
 
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                // Set the active mob
-                Optional<ActiveMob> opt = MCPets.getMythicMobs().getMobManager().getActiveMob(ent.getUniqueId());
-                opt.ifPresent(pet::setActiveMob);
-                // The taming progress should be set at the given value
-                pet.setDefaultTamingValue(tamingProgress);
-                pet.setFollowOwner(followOnTame);
-            }
-        }.runTaskLater(MCPets.getInstance(), 1L);
+        Bukkit.getScheduler().runTask(
+                MCPets.getInstance(),
+                () -> {
+                    Optional<ActiveMob> activeMob = MCPets.getMythicMobs().getMobManager().getActiveMob(entity.getUniqueId());
+
+                    activeMob.ifPresent(pet::setActiveMob);
+
+                    pet.setDefaultTamingValue(tamingProgress);
+                    pet.setFollowOwner(followOnTame);
+                }
+        );
 
         return SkillResult.SUCCESS;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/SetPetMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/SetPetMechanic.java
@@ -1,51 +1,74 @@
 package fr.nocsy.mcpets.mythicmobs.mechanics;
 
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.PetDespawnReason;
+
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.skills.SkillMechanic;
 import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.api.config.MythicLineConfig;
 import io.lumine.mythic.api.skills.ITargetedEntitySkill;
-import io.lumine.mythic.api.skills.SkillMetadata;
-import io.lumine.mythic.api.skills.SkillResult;
-import io.lumine.mythic.bukkit.BukkitAdapter;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 
-public class SetPetMechanic implements ITargetedEntitySkill {
+@MythicMechanic(
+        name = "setPet"
+)
+public class SetPetMechanic extends SkillMechanic implements ITargetedEntitySkill {
 
-    private String petId;
-    private boolean followOwner = true;
-    private boolean mustHavePermission;
+    private final String petId;
+    private final boolean followOwner;
+    private final boolean mustHavePermission;
 
-    public SetPetMechanic(MythicLineConfig config) {
-        this.petId = config.getString(new String[]{"id"}, this.petId);
-        this.followOwner = config.getBoolean(new String[]{"followOwner", "fo"}, this.followOwner);
-        this.mustHavePermission =  config.getBoolean(new String[]{"mustHavePermission","permCheck"}, this.mustHavePermission);
+    public SetPetMechanic(MythicMechanicLoadEvent event) {
+        super(event.getContainer().getManager(), event.getContainer().getFile());
+
+        MythicLineConfig config = event.getConfig();
+
+        petId = config.getString(new String[]{"id"}, "");
+        followOwner = config.getBoolean(new String[]{"followOwner", "fo"}, true);
+        mustHavePermission = config.getBoolean(new String[]{"mustHavePermission", "permCheck"}, false);
     }
 
+    @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
-        Entity player = BukkitAdapter.adapt(target);
-
-        if (player instanceof Player) {
-            Pet pet = Pet.getFromId(petId);
-            if (pet == null)
-                return SkillResult.CONDITION_FAILED;
-
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    MCPets.getMythicMobs().getMobManager().getActiveMob(data.getCaster().getEntity().getUniqueId())
-                            .ifPresent(activeMob -> pet.changeActiveMobTo(
-                                    activeMob,
-                                    ((Player)player).getUniqueId(),
-                                    followOwner,
-                                    PetDespawnReason.SETPET_REPLACED));
-                }
-            }.runTaskLater(MCPets.getInstance(), 1L);
-            return SkillResult.SUCCESS;
+        Entity entity = BukkitAdapter.adapt(target);
+        if (!(entity instanceof Player player)) {
+            return SkillResult.CONDITION_FAILED;
         }
-        return SkillResult.CONDITION_FAILED;
+
+        Pet pet = Pet.getFromId(petId);
+        if (pet == null) {
+            return SkillResult.CONDITION_FAILED;
+        }
+        
+        if (mustHavePermission && !player.hasPermission(pet.getPermission())) {
+            return SkillResult.CONDITION_FAILED;
+        }
+
+        Bukkit.getScheduler().runTask(
+                MCPets.getInstance(),
+                () -> MCPets.getMythicMobs()
+                        .getMobManager()
+                        .getActiveMob(data.getCaster().getEntity().getUniqueId())
+                        .ifPresent(activeMob ->
+                                pet.changeActiveMobTo(
+                                        activeMob,
+                                        player.getUniqueId(),
+                                        followOwner,
+                                        PetDespawnReason.SETPET_REPLACED
+                                )
+                        )
+        );
+
+        return SkillResult.SUCCESS;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/placeholders/PetHealthPlaceholder.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/placeholders/PetHealthPlaceholder.java
@@ -6,9 +6,9 @@ import fr.nocsy.mcpets.data.Pet;
 
 import io.lumine.mythic.api.skills.SkillCaster;
 import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.utils.annotations.MythicPlaceholder;
 import io.lumine.mythic.core.skills.placeholders.PlaceholderContext;
 import io.lumine.mythic.core.skills.placeholders.types.GenericPlaceholderTypes.IntegerPlaceholder;
-import io.lumine.mythic.core.utils.annotations.MythicPlaceholder;
 
 @MythicPlaceholder(placeholder = "pet.hp", version = "5.9")
 public class PetHealthPlaceholder extends PetPlaceholder<Integer> implements IntegerPlaceholder {

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/placeholders/PetMaxHealthPlaceholder.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/placeholders/PetMaxHealthPlaceholder.java
@@ -6,9 +6,9 @@ import fr.nocsy.mcpets.data.Pet;
 
 import io.lumine.mythic.api.skills.SkillCaster;
 import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.core.utils.annotations.MythicPlaceholder;
 import io.lumine.mythic.core.skills.placeholders.PlaceholderContext;
 import io.lumine.mythic.core.skills.placeholders.types.GenericPlaceholderTypes.IntegerPlaceholder;
-import io.lumine.mythic.core.utils.annotations.MythicPlaceholder;
 
 @MythicPlaceholder(placeholder = "pet.max.hp", version = "5.9")
 public class PetMaxHealthPlaceholder extends PetPlaceholder<Integer> implements IntegerPlaceholder {

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/targeters/TargeterPetFromOwner.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/targeters/TargeterPetFromOwner.java
@@ -1,39 +1,58 @@
 package fr.nocsy.mcpets.mythicmobs.targeters;
 
+import java.util.Set;
+import java.util.List;
+import java.util.HashSet;
+import java.util.Collection;
+import java.util.Collections;
+
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.utils.debug.Debugger;
-import io.lumine.mythic.api.adapters.AbstractEntity;
-import io.lumine.mythic.api.config.MythicLineConfig;
+
 import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.bukkit.adapters.BukkitPlayer;
 import io.lumine.mythic.core.skills.targeters.IEntitySelector;
-import org.bukkit.entity.Player;
+import io.lumine.mythic.core.utils.annotations.MythicTargeter;
+import io.lumine.mythic.bukkit.events.MythicTargeterLoadEvent;
 
-import java.util.Collection;
-import java.util.HashSet;
-
+@MythicTargeter(
+        name = "petFromOwner"
+)
 public class TargeterPetFromOwner extends IEntitySelector {
 
-    public TargeterPetFromOwner(MythicLineConfig paramMythicLineConfig) {
-        super(MCPets.getMythicMobs().getSkillManager(),paramMythicLineConfig);
+    public TargeterPetFromOwner(MythicTargeterLoadEvent event) {
+        super(MCPets.getMythicMobs().getSkillManager(), event.getConfig());
     }
 
-    public Collection<AbstractEntity> getEntities(SkillMetadata paramSkillMetadata) {
-        HashSet<AbstractEntity> hashSet = new HashSet<>();
-        AbstractEntity caster = paramSkillMetadata.getCaster().getEntity();
-        if (caster instanceof BukkitPlayer) {
-            Pet pet = Pet.fromOwner(caster.getBukkitEntity().getUniqueId());
-            if (pet != null)
-            {
-                hashSet.add(pet.getActiveMob().getEntity());
-                Debugger.send("Targeter @PetFromOwner found pet " + pet.getId() + " for owner " + caster.getUniqueId());
-            } else {
-                Debugger.send("Targeter @PetFromOwner found no pet for owner " + caster.getUniqueId());
-            }
-        } else {
+    @Override
+    public Collection<AbstractEntity> getEntities(SkillMetadata metadata) {
+        AbstractEntity caster = metadata.getCaster().getEntity();
+        if (!(caster instanceof BukkitPlayer)) {
             Debugger.send("Targeter @PetFromOwner called with unknown caster type: " + caster.getClass().getName());
+            return Collections.emptySet();
         }
-        return hashSet;
+
+        List<Pet> pets = Pet.getActivePetsForOwner(caster.getUniqueId());
+        if (pets.isEmpty()) {
+            Debugger.send("Targeter @PetFromOwner found no pets for owner " + caster.getUniqueId());
+            return Collections.emptySet();
+        }
+
+        Set<AbstractEntity> entities = new HashSet<>();
+
+        for (Pet pet : pets) {
+            if (pet.getActiveMob() == null || pet.getActiveMob().getEntity() == null) {
+                continue;
+            }
+
+            entities.add(pet.getActiveMob().getEntity());
+
+            Debugger.send("Targeter @PetFromOwner found pet " + pet.getId() + " for owner " + caster.getUniqueId());
+        }
+
+        return entities;
     }
+
 }

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/targeters/TargeterPetOwner.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/targeters/TargeterPetOwner.java
@@ -1,29 +1,44 @@
 package fr.nocsy.mcpets.mythicmobs.targeters;
 
+import java.util.Collection;
+import java.util.Collections;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.data.Pet;
-import io.lumine.mythic.api.adapters.AbstractEntity;
-import io.lumine.mythic.api.config.MythicLineConfig;
-import io.lumine.mythic.api.skills.SkillMetadata;
+
 import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.core.skills.targeters.IEntitySelector;
-import org.bukkit.Bukkit;
+import io.lumine.mythic.core.utils.annotations.MythicTargeter;
+import io.lumine.mythic.bukkit.events.MythicTargeterLoadEvent;
 
-import java.util.Collection;
-import java.util.HashSet;
-
+@MythicTargeter(
+        name = "petOwner"
+)
 public class TargeterPetOwner extends IEntitySelector {
 
-    public TargeterPetOwner(MythicLineConfig paramMythicLineConfig) {
-        super(MCPets.getMythicMobs().getSkillManager(),paramMythicLineConfig);
+    public TargeterPetOwner(MythicTargeterLoadEvent event) {
+        super(MCPets.getMythicMobs().getSkillManager(), event.getConfig());
     }
 
-    public Collection<AbstractEntity> getEntities(SkillMetadata paramSkillMetadata) {
-        HashSet<AbstractEntity> hashSet = new HashSet<>();
-        AbstractEntity abstractEntity = paramSkillMetadata.getCaster().getEntity();
-        Pet pet = Pet.getFromEntity(abstractEntity.getBukkitEntity());
-        if (pet != null && Bukkit.getPlayer(pet.getOwner()) != null)
-            hashSet.add(BukkitAdapter.adapt(Bukkit.getPlayer(pet.getOwner())));
-        return hashSet;
+    @Override
+    public Collection<AbstractEntity> getEntities(SkillMetadata meta) {
+        AbstractEntity caster = meta.getCaster().getEntity();
+        Pet pet = Pet.getFromEntity(caster.getBukkitEntity());
+
+        if (pet != null) {
+            Player owner = Bukkit.getPlayer(pet.getOwner());
+
+            if (owner != null) {
+                return Collections.singleton(BukkitAdapter.adapt(owner));
+            }
+        }
+
+        return Collections.emptySet();
     }
+
 }


### PR DESCRIPTION
Refactor MythicMobs targeters, conditions and mechanics into the new CustomComponentRegistry.
- `petFromOwner` targeter will now target all active pets, instead of just the first spawned pet for the player
- `setPet` now checks the `mustHavePermission` option